### PR TITLE
Write intermediate tractor catalogs

### DIFF
--- a/py/legacyanalysis/euclid.py
+++ b/py/legacyanalysis/euclid.py
@@ -1618,9 +1618,6 @@ def stage_plot_model(tims=None, bands=None, targetwcs=None,
     print('Read', len(ACS), 'ACS catalog entries')
     ACS.cut(ACS.brick_primary)
     print('Cut to', len(ACS), 'primary')
-    ACS.shapeexp = np.vstack((ACS.shapeexp_r, ACS.shapeexp_e1, ACS.shapeexp_e2)).T
-    ACS.shapedev = np.vstack((ACS.shapedev_r, ACS.shapedev_e1, ACS.shapedev_e2)).T
-
     ACS.cut(ACS.decam_flux_ivar > 0)
 
     tim = tims[0]
@@ -1631,8 +1628,7 @@ def stage_plot_model(tims=None, bands=None, targetwcs=None,
     print('Cut to', len(ACS), 'in image')
 
     print('Creating catalog objects...')
-    cat = read_fits_catalog(ACS, ellipseClass=EllipseE, allbands=bands,
-                            bands=bands)
+    cat = read_fits_catalog(ACS, allbands=bands, bands=bands)
     tr = Tractor(tims, cat)
 
     # Clip sizes of big models
@@ -1982,9 +1978,6 @@ def main():
         print('Cut to', len(T), 'primary')
         #T.about()
 
-        T.shapeexp = np.vstack((T.shapeexp_r, T.shapeexp_e1, T.shapeexp_e2)).T
-        T.shapedev = np.vstack((T.shapedev_r, T.shapedev_e1, T.shapedev_e2)).T
-
         print('RA', T.ra.min(), T.ra.max())
         print('Dec', T.dec.min(), T.dec.max())
 
@@ -2055,8 +2048,7 @@ def main():
                         continue
 
                     bands = ['w']
-                    wcat = read_fits_catalog(T[I], ellipseClass=EllipseE, allbands=bands,
-                                             bands=bands)
+                    wcat = read_fits_catalog(T[I], allbands=bands, bands=bands)
                     for src in wcat:
                         src.brightness = NanoMaggies(**dict([(b, 1.) for b in bands]))
                 
@@ -2253,9 +2245,6 @@ def forced_photometry(opt, survey):
         B = 8
         opti = CeresOptimizer(BW=B, BH=B)
     
-    T.shapeexp = np.vstack((T.shapeexp_r, T.shapeexp_e1, T.shapeexp_e2)).T
-    T.shapedev = np.vstack((T.shapedev_r, T.shapedev_e1, T.shapedev_e2)).T
-
     ccds = survey.get_ccds_readonly()
     #I = np.flatnonzero(ccds.camera == 'megacam')
     #print(len(I), 'MegaCam CCDs')
@@ -2332,8 +2321,7 @@ def forced_photometry(opt, survey):
     # convert to string
     bands = ''.join(bands)
     
-    cat = read_fits_catalog(T, ellipseClass=EllipseE, allbands=bands,
-                            bands=bands)
+    cat = read_fits_catalog(T, allbands=bands, bands=bands)
     for src in cat:
         src.brightness = NanoMaggies(**dict([(b, 1.) for b in bands]))
 

--- a/py/legacyanalysis/lsb.py
+++ b/py/legacyanalysis/lsb.py
@@ -102,10 +102,6 @@ def stage_1(expnum=431202, extname='S19', plotprefix='lsb', plots=False,
         print 'Cut to', len(T), 'brick_primary'
         T.cut((T.out_of_bounds == False) * (T.left_blob == False))
         print 'Cut to', len(T), 'not out-of-bound or left-blob'
-        
-        T.shapeexp = np.vstack((T.shapeexp_r, T.shapeexp_e1, T.shapeexp_e2)).T
-        T.shapedev = np.vstack((T.shapedev_r, T.shapedev_e1, T.shapedev_e2)).T
-        
         print 'Brightest z-band:', np.max(T.decam_flux[:,4])
         print 'Brightest r-band:', np.max(T.decam_flux[:,2])
     

--- a/py/legacyanalysis/wise-cutouts.py
+++ b/py/legacyanalysis/wise-cutouts.py
@@ -101,9 +101,7 @@ def wise_cutouts(ra, dec, radius, ps, pixscale=2.75, tractor_base='.',
 
     ra,dec = T.ra, T.dec
 
-    T.shapeexp = np.vstack((T.shapeexp_r, T.shapeexp_e1, T.shapeexp_e2)).T
-    T.shapedev = np.vstack((T.shapedev_r, T.shapedev_e1, T.shapedev_e2)).T
-    srcs = read_fits_catalog(T, ellipseClass=EllipseE)
+    srcs = read_fits_catalog(T)
 
     wbands = [1,2]
     wanyband = 'w'

--- a/py/legacypipe/catalog.py
+++ b/py/legacypipe/catalog.py
@@ -157,7 +157,8 @@ def _get_tractor_fits_values(T, cat, pat):
 
 
 def read_fits_catalog(T, hdr=None, invvars=False, bands='grz',
-                      allbands = 'ugrizY', ellipseClass=None):
+                      allbands = 'ugrizY', ellipseClass=EllipseE,
+                      unpackShape=True):
     from tractor import NanoMaggies
     '''
     This is currently a weird hybrid of dynamic and hard-coded.
@@ -166,10 +167,24 @@ def read_fits_catalog(T, hdr=None, invvars=False, bands='grz',
 
     If invvars=True, return sources,invvars
     where invvars is a list matching sources.getParams()
+
+    If *ellipseClass* is set, assume that type for galaxy shapes; if None,
+    read the type from the header.
+
+    If *unpackShapes* is True and *ellipseClass* is EllipseE, read
+    catalog entries "shapeexp_r", "shapeexp_e1", "shapeexp_e2" rather than
+    "shapeExp", and similarly for "dev".
     '''
     if hdr is None:
         hdr = T._header
     rev_typemap = dict([(v,k) for k,v in fits_typemap.items()])
+
+    if unpackShape and ellipseClass != EllipseE:
+        print('Not doing unpackShape because ellipseClass != EllipseE.')
+        unpackShape = False
+    if unpackShape:
+        T.shapeexp = np.vstack((T.shapeexp_r, T.shapeexp_e1, T.shapeexp_e2)).T
+        T.shapedev = np.vstack((T.shapedev_r, T.shapedev_e1, T.shapedev_e2)).T
 
     ivbandcols = []
 

--- a/py/legacypipe/catalog.py
+++ b/py/legacypipe/catalog.py
@@ -117,6 +117,15 @@ def prepare_fits_catalog(cat, invvars, T, hdr, filts, fs, allbands = 'ugrizY',
         # Heh, "no uncertainty here!"
         T.delete_column('%stype_ivar' % prefix)
     cat.setParams(params0)
+
+    # mod
+    T.ra += (T.ra <   0) * 360.
+    T.ra -= (T.ra > 360) * 360.
+
+    T.ra_ivar  = T.ra_ivar .astype(np.float32)
+    T.dec_ivar = T.dec_ivar.astype(np.float32)
+
+    T.decam_flux[T.decam_flux_ivar == 0] = 0.
     
     return T, hdr
 

--- a/py/legacypipe/catalog.py
+++ b/py/legacypipe/catalog.py
@@ -38,14 +38,15 @@ def _source_param_types(src):
     return types
     
 
-def prepare_fits_catalog(cat, invvars, T, hdr, filts, fs, allbands = 'ugrizY',
+def prepare_fits_catalog(cat, invvars, T, hdr, filts, fs, allbands=None,
                          prefix='', save_invvars=True, unpackShape=True):
-
     if T is None:
         T = fits_table()
     if hdr is None:
         import fitsio
         hdr = fitsio.FITSHDR()
+    if allbands is None:
+        allbands = filts
 
     hdr.add_record(dict(name='TR_VER', value=1, comment='Tractor output format version'))
 
@@ -184,9 +185,8 @@ def _get_tractor_fits_values(T, cat, pat, unpackShape=True):
 
 
 def read_fits_catalog(T, hdr=None, invvars=False, bands='grz',
-                      allbands = 'ugrizY', ellipseClass=EllipseE,
+                      allbands=None, ellipseClass=EllipseE,
                       unpackShape=True, fluxPrefix='decam_'):
-    from tractor import NanoMaggies
     '''
     This is currently a weird hybrid of dynamic and hard-coded.
 
@@ -202,8 +202,11 @@ def read_fits_catalog(T, hdr=None, invvars=False, bands='grz',
     catalog entries "shapeexp_r", "shapeexp_e1", "shapeexp_e2" rather than
     "shapeExp", and similarly for "dev".
     '''
+    from tractor import NanoMaggies
     if hdr is None:
         hdr = T._header
+    if allbands is None:
+        allbands = bands    
     rev_typemap = dict([(v,k) for k,v in fits_typemap.items()])
 
     if unpackShape and ellipseClass != EllipseE:

--- a/py/legacypipe/detection.py
+++ b/py/legacypipe/detection.py
@@ -181,8 +181,8 @@ def run_sed_matched_filters(SEDs, bands, detmaps, detivs, omit_xy,
     Tnew = fits_table()
     Tnew.ra  = pr
     Tnew.dec = pd
-    Tnew.tx = peakx
-    Tnew.ty = peaky
+    Tnew.tx = peakx.astype(np.float32)
+    Tnew.ty = peaky.astype(np.float32)
     assert(len(peaksn) == len(Tnew))
     assert(len(apsn) == len(Tnew))
     Tnew.peaksn = np.array(peaksn)

--- a/py/legacypipe/forced_photom_decam.py
+++ b/py/legacypipe/forced_photom_decam.py
@@ -189,10 +189,7 @@ def main(survey=None, opt=None):
     surveydir = survey.get_survey_dir()
     del survey
         
-    T.shapeexp = np.vstack((T.shapeexp_r, T.shapeexp_e1, T.shapeexp_e2)).T
-    T.shapedev = np.vstack((T.shapedev_r, T.shapedev_e1, T.shapedev_e2)).T
-
-    cat = read_fits_catalog(T, ellipseClass=EllipseE)
+    cat = read_fits_catalog(T)
     # print('Got cat:', cat)
 
     print('Read catalog:', Time()-t0)

--- a/py/legacypipe/format_catalog.py
+++ b/py/legacypipe/format_catalog.py
@@ -2,11 +2,11 @@ from __future__ import print_function
 import sys
 import os
 
+import numpy as np
+
 import fitsio
 
 from astrometry.util.fits import fits_table, merge_tables
-
-from tractor.sfd import SFDMap
 
 from catalog import prepare_fits_catalog
 
@@ -37,7 +37,7 @@ def main(args=None):
     print('Wrote', opt.out)
     
 def format_catalog(T, hdr, primhdr, allbands, outfn,
-                   in_flux_prefix='', flux_prefix='')
+                   in_flux_prefix='', flux_prefix=''):
     
     # Retrieve the bands in this catalog.
     bands = []
@@ -63,6 +63,73 @@ def format_catalog(T, hdr, primhdr, allbands, outfn,
     primhdr.add_record(dict(name='ALLBANDS', value=allbands,
                             comment='Band order in array values'))
 
+    has_wise = 'wise_flux' in T.columns()
+    has_wise_lc = 'wise_lc_flux' in T.columns()
+    has_ap = 'decam_apflux' in T.columns()
+    
+    from tractor.sfd import SFDMap
+    print('Reading SFD maps...')
+    sfd = SFDMap()
+    filts = ['%s %s' % ('DES', f) for f in allbands]
+    wisebands = ['WISE W1', 'WISE W2', 'WISE W3', 'WISE W4']
+    ebv,ext = sfd.extinction(filts + wisebands, T.ra, T.dec, get_ebv=True)
+    T.ebv = ebv.astype(np.float32)
+    ext = ext.astype(np.float32)
+    decam_ext = ext[:,:len(allbands)]
+    T.decam_mw_transmission = 10.**(-decam_ext / 2.5)
+    if has_wise:
+        wise_ext  = ext[:,len(allbands):]
+        T.wise_mw_transmission  = 10.**(-wise_ext / 2.5)
+
+    # Column ordering...
+    cols = [
+        'brickid', 'brickname', 'objid', 'brick_primary', 'blob', 'ninblob',
+        'tycho2inblob', 'type', 'ra', 'ra_ivar', 'dec', 'dec_ivar',
+        'bx', 'by', 'bx0', 'by0', 'left_blob', 'out_of_bounds',
+        'dchisq', 'ebv', 
+        'cpu_source', 'cpu_blob',
+        'blob_width', 'blob_height', 'blob_npix', 'blob_nimages',
+        'blob_totalpix',
+        'decam_flux', 'decam_flux_ivar',
+        ]
+
+    if has_ap:
+        cols.extend(['decam_apflux', 'decam_apflux_resid','decam_apflux_ivar'])
+
+    cols.extend(['decam_mw_transmission', 'decam_nobs',
+        'decam_rchi2', 'decam_fracflux', 'decam_fracmasked', 'decam_fracin',
+        'decam_anymask', 'decam_allmask', 'decam_psfsize',
+        'decam_depth', 'decam_galdepth' ])
+
+    if has_wise:
+        cols.extend([
+            'wise_flux', 'wise_flux_ivar',
+            'wise_mw_transmission', 'wise_nobs', 'wise_fracflux','wise_rchi2'])
+
+    if has_wise_lc:
+        cols.extend([
+            'wise_lc_flux', 'wise_lc_flux_ivar',
+            'wise_lc_nobs', 'wise_lc_fracflux', 'wise_lc_rchi2','wise_lc_mjd'])
+
+    cols.extend([
+        'fracdev', 'fracdev_ivar', 'shapeexp_r', 'shapeexp_r_ivar',
+        'shapeexp_e1', 'shapeexp_e1_ivar',
+        'shapeexp_e2', 'shapeexp_e2_ivar',
+        'shapedev_r',  'shapedev_r_ivar',
+        'shapedev_e1', 'shapedev_e1_ivar',
+        'shapedev_e2', 'shapedev_e2_ivar',])
+
+    print('Columns:', cols)
+    print('T columns:', T.columns())
+    
+    # match case to T.
+    cc = T.get_columns()
+    cclower = [c.lower() for c in cc]
+    for i,c in enumerate(cols):
+        if (not c in cc) and c in cclower:
+            j = cclower.index(c)
+            cols[i] = cc[j]
+    
     # Units
     deg='deg'
     degiv='1/deg^2'
@@ -84,7 +151,7 @@ def format_catalog(T, hdr, primhdr, allbands, outfn,
     # Reformat as list aligned with cols
     units = [units.get(c, '') for c in cols]
     
-    T.writeto(outfn, header=hdr, primheader=primhdr, units=units)
+    T.writeto(outfn, columns=cols, header=hdr, primheader=primhdr, units=units)
         
 if __name__ == '__main__':
     main()

--- a/py/legacypipe/format_catalog.py
+++ b/py/legacypipe/format_catalog.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 import sys
 import os
 
+import fitsio
+
 from astrometry.util.fits import fits_table, merge_tables
 
 from tractor.sfd import SFDMap
@@ -25,7 +27,8 @@ def main(args=None):
 
     T = fits_table(opt.infn)
     hdr = T.get_header()
-
+    primhdr = fitsio.read_header(opt.infn)
+    
     allbands = opt.allbands
     
     # Retrieve the bands in this catalog.
@@ -40,19 +43,40 @@ def main(args=None):
 
     B = np.array([allbands.index(band) for band in bands])
 
-    atypes = dict(nobs=np.uint8, anymask=TT.anymask.dtype,
-                  allmask=TT.allmask.dtype)
-
     for k in ['rchi2', 'fracflux', 'fracmasked', 'fracin', 'nobs',
               'anymask', 'allmask', 'psfsize', 'depth', 'galdepth']:
         incol = '%s%s' % (opt.in_flux_prefix, k)
-        X = TT.get(incol)
-        A = np.zeros((len(TT), len(allbands)), X.dtype)
+        X = T.get(incol)
+        A = np.zeros((len(T), len(allbands)), X.dtype)
         A[:,B] = X
-        TT.delete_column(incol)
-        TT.set('%s%s' % (opt.flux_prefix, k), A)
+        T.delete_column(incol)
+        T.set('%s%s' % (opt.flux_prefix, k), A)
         
+    primhdr.add_record(dict(name='ALLBANDS', value=allbands,
+                            comment='Band order in array values'))
+
+    # Units
+    deg='deg'
+    degiv='1/deg^2'
+    flux = 'nanomaggy'
+    fluxiv = '1/nanomaggy^2'
+    units = dict(
+        ra=deg, dec=deg, ra_ivar=degiv, dec_ivar=degiv, ebv='mag',
+
+    ##### FIXME
+        decam_flux=flux, decam_flux_ivar=fluxiv,
+        decam_apflux=flux, decam_apflux_ivar=fluxiv, decam_apflux_resid=flux,
+        decam_depth=fluxiv, decam_galdepth=fluxiv,
+
+        wise_flux=flux, wise_flux_ivar=fluxiv,
+        wise_lc_flux=flux, wise_lc_flux_ivar=fluxiv,
+        shapeexp_r='arcsec', shapeexp_r_ivar='1/arcsec^2',
+        shapedev_r='arcsec', shapedev_r_ivar='1/arcsec^2')
+    # Reformat as list aligned with cols
+    units = [units.get(c, '') for c in cols]
     
+    T.writeto(opt.outfn, header=hdr, primheader=primhdr, units=units)
+        
 if __name__ == '__main__':
     main()
     

--- a/py/legacypipe/format_catalog.py
+++ b/py/legacypipe/format_catalog.py
@@ -1,0 +1,58 @@
+from __future__ import print_function
+import sys
+import os
+
+from astrometry.util.fits import fits_table, merge_tables
+
+from tractor.sfd import SFDMap
+
+from catalog import prepare_fits_catalog
+
+def main(args=None):
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--in', dest='infn',
+                        help='Input intermediate tractor catalog file')
+    parser.add_argument('--out', help='Output catalog filename')
+    parser.add_argument('--allbands', default='ugrizY',
+                        help='Full set of bands to expand arrays out to')
+    parser.add_argument('--flux-prefix', default='',
+                        help='Prefix on FLUX etc columns (eg, "decam_" to match DR3) for output file')
+    parser.add_argument('--in-flux-prefix', default='',
+                        help='Prefix on FLUX etc columns (eg, "decam_" to match DR3) for input file')
+
+    opt = parser.parse_args(args=args)
+
+    T = fits_table(opt.infn)
+    hdr = T.get_header()
+
+    allbands = opt.allbands
+    
+    # Retrieve the bands in this catalog.
+    bands = []
+    for i in range(10):
+        b = hdr.get('BAND%i' % i)
+        if b is None:
+            break
+        bands.append(b)
+
+    # Expand out FLUX and related fields.
+
+    B = np.array([allbands.index(band) for band in bands])
+
+    atypes = dict(nobs=np.uint8, anymask=TT.anymask.dtype,
+                  allmask=TT.allmask.dtype)
+
+    for k in ['rchi2', 'fracflux', 'fracmasked', 'fracin', 'nobs',
+              'anymask', 'allmask', 'psfsize', 'depth', 'galdepth']:
+        incol = '%s%s' % (opt.in_flux_prefix, k)
+        X = TT.get(incol)
+        A = np.zeros((len(TT), len(allbands)), X.dtype)
+        A[:,B] = X
+        TT.delete_column(incol)
+        TT.set('%s%s' % (opt.flux_prefix, k), A)
+        
+    
+if __name__ == '__main__':
+    main()
+    

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -2016,7 +2016,6 @@ def stage_writecat(
     fs = None
     T2,hdr = prepare_fits_catalog(cat, invvars, TT, hdr, bands, fs,
                                   allbands=allbands)
-
     # mod
     T2.ra += (T2.ra <   0) * 360.
     T2.ra -= (T2.ra > 360) * 360.
@@ -2185,7 +2184,7 @@ def stage_writecat(
         'shapedev_e1', 'shapedev_e1_ivar',
         'shapedev_e2', 'shapedev_e2_ivar',])
 
-    # TUNIT cards.
+    # Units
     deg='deg'
     degiv='1/deg^2'
     flux = 'nanomaggy'
@@ -2199,10 +2198,8 @@ def stage_writecat(
         wise_lc_flux=flux, wise_lc_flux_ivar=fluxiv,
         shapeexp_r='arcsec', shapeexp_r_ivar='1/arcsec^2',
         shapedev_r='arcsec', shapedev_r_ivar='1/arcsec^2')
-
-    for i,col in enumerate(cols):
-        if col in units:
-            hdr.add_record(dict(name='TUNIT%i' % (i+1), value=units[col]))
+    # Reformat as list aligned with cols
+    units = [units.get(c, None) for c in cols]
 
     # match case to T2.
     cc = T2.get_columns()
@@ -2214,7 +2211,8 @@ def stage_writecat(
 
     with survey.write_output('tractor', brick=brickname) as out:
         print('tractor cat data, fn=', out.fn)
-        T2.writeto(out.fn, primheader=primhdr, header=hdr, columns=cols)
+        T2.writeto(out.fn, primheader=primhdr, header=hdr, columns=cols,
+                   units=units)
         print('Wrote', out.fn)
 
     # produce per-brick sha1sums file

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1960,12 +1960,9 @@ def stage_writecat(
     fs = None
     T2,hdr = prepare_fits_catalog(cat, invvars, TT, hdr, bands, fs,
                                   allbands=allbands)
-
     primhdr = fitsio.FITSHDR()
     for r in version_header.records():
         primhdr.add_record(r)
-    primhdr.add_record(dict(name='ALLBANDS', value=allbands,
-                            comment='Band order in array values'))
     primhdr.add_record(dict(name='PRODTYPE', value='catalog',
                             comment='NOAO data product type'))
 
@@ -2107,23 +2104,10 @@ def stage_writecat(
         'shapedev_e1', 'shapedev_e1_ivar',
         'shapedev_e2', 'shapedev_e2_ivar',])
 
-    # Units
-    deg='deg'
-    degiv='1/deg^2'
-    flux = 'nanomaggy'
-    fluxiv = '1/nanomaggy^2'
-    units = dict(
-        ra=deg, dec=deg, ra_ivar=degiv, dec_ivar=degiv, ebv='mag',
-        decam_flux=flux, decam_flux_ivar=fluxiv,
-        decam_apflux=flux, decam_apflux_ivar=fluxiv, decam_apflux_resid=flux,
-        decam_depth=fluxiv, decam_galdepth=fluxiv,
-        wise_flux=flux, wise_flux_ivar=fluxiv,
-        wise_lc_flux=flux, wise_lc_flux_ivar=fluxiv,
-        shapeexp_r='arcsec', shapeexp_r_ivar='1/arcsec^2',
-        shapedev_r='arcsec', shapedev_r_ivar='1/arcsec^2')
-    # Reformat as list aligned with cols
-    units = [units.get(c, '') for c in cols]
 
+    print('Columns:', cols)
+    print('T2 columns:', T2.columns())
+    
     # match case to T2.
     cc = T2.get_columns()
     cclower = [c.lower() for c in cc]

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -900,9 +900,7 @@ def _subtract_onbricks_sources(survey, brick, allow_missing_brickq,
     # Create sources for these catalog entries
     ### see forced-photom-decam.py for some additional patchups?
 
-    B.shapeexp = np.vstack((B.shapeexp_r, B.shapeexp_e1, B.shapeexp_e2)).T
-    B.shapedev = np.vstack((B.shapedev_r, B.shapedev_e1, B.shapedev_e2)).T
-    bcat = read_fits_catalog(B, ellipseClass=EllipseE)
+    bcat = read_fits_catalog(B)
     print('Created', len(bcat), 'tractor catalog objects')
 
     # Add the new sources to the 'avoid_[xy]' lists, which are

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -2046,6 +2046,7 @@ def stage_writecat(
         print('Wrote', out.fn)
 
     ### FIXME -- convert intermediate tractor catalog to final, for now...
+    ### FIXME -- note that this is now the only place where 'allbands' is used.
     from format_catalog import format_catalog
     with survey.write_output('tractor', brick=brickname) as out:
         format_catalog(T2, hdr, primhdr, allbands, out.fn, flux_prefix='decam_')

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1378,64 +1378,24 @@ def _format_all_models(T, newcat, BB, bands, allbands):
                np.array([m.get(srctype,0) 
                          for m in BB.all_model_cpu]).astype(np.float32))
 
-    TT.delete_column('psf_shapeExp')
-    TT.delete_column('psf_shapeDev')
-    TT.delete_column('psf_fracDev')
-    TT.delete_column('psf_shapeExp_ivar')
-    TT.delete_column('psf_shapeDev_ivar')
-    TT.delete_column('psf_fracDev_ivar')
-    TT.delete_column('psf_type')
-    TT.delete_column('simp_shapeExp')
-    TT.delete_column('simp_shapeDev')
-    TT.delete_column('simp_fracDev')
-    TT.delete_column('simp_shapeExp_ivar')
-    TT.delete_column('simp_shapeDev_ivar')
-    TT.delete_column('simp_fracDev_ivar')
-    TT.delete_column('simp_type')
-    TT.delete_column('dev_shapeExp')
-    TT.delete_column('dev_shapeExp_ivar')
+    # remove silly columns
+    for col in TT.columns():
+        # all types
+        if '_type' in col:
+            TT.delete_column(col)
+            continue
+        # shapes for shapeless types
+        if (('psf_' in col or 'simp_' in col) and
+            ('shape' in col or 'fracDev' in col)):
+            TT.delete_column(col)
+            continue
+        # shapeDev for exp sources, vice versa
+        if (('exp_' in col and 'Dev' in col) or
+            ('dev_' in col and 'Exp' in col)):
+            TT.delete_column(col)
+            continue
     TT.delete_column('dev_fracDev')
     TT.delete_column('dev_fracDev_ivar')
-    TT.delete_column('dev_type')
-    TT.delete_column('exp_shapeDev')
-    TT.delete_column('exp_shapeDev_ivar')
-    TT.delete_column('exp_fracDev')
-    TT.delete_column('exp_fracDev_ivar')
-    TT.delete_column('exp_type')
-    TT.delete_column('comp_type')
-    # Unpack ellipses
-    TT.dev_shape_r  = TT.dev_shapeDev[:,0]
-    TT.dev_shape_e1 = TT.dev_shapeDev[:,1]
-    TT.dev_shape_e2 = TT.dev_shapeDev[:,2]
-    TT.exp_shape_r  = TT.exp_shapeExp[:,0]
-    TT.exp_shape_e1 = TT.exp_shapeExp[:,1]
-    TT.exp_shape_e2 = TT.exp_shapeExp[:,2]
-    TT.comp_shapeDev_r  = TT.comp_shapeDev[:,0]
-    TT.comp_shapeDev_e1 = TT.comp_shapeDev[:,1]
-    TT.comp_shapeDev_e2 = TT.comp_shapeDev[:,2]
-    TT.comp_shapeExp_r  = TT.comp_shapeExp[:,0]
-    TT.comp_shapeExp_e1 = TT.comp_shapeExp[:,1]
-    TT.comp_shapeExp_e2 = TT.comp_shapeExp[:,2]
-    TT.delete_column('dev_shapeDev')
-    TT.delete_column('exp_shapeExp')
-    TT.delete_column('comp_shapeDev')
-    TT.delete_column('comp_shapeExp')
-    TT.dev_shape_r_ivar  = TT.dev_shapeDev_ivar[:,0]
-    TT.dev_shape_e1_ivar = TT.dev_shapeDev_ivar[:,1]
-    TT.dev_shape_e2_ivar = TT.dev_shapeDev_ivar[:,2]
-    TT.exp_shape_r_ivar  = TT.exp_shapeExp_ivar[:,0]
-    TT.exp_shape_e1_ivar = TT.exp_shapeExp_ivar[:,1]
-    TT.exp_shape_e2_ivar = TT.exp_shapeExp_ivar[:,2]
-    TT.comp_shapeDev_r_ivar  = TT.comp_shapeDev_ivar[:,0]
-    TT.comp_shapeDev_e1_ivar = TT.comp_shapeDev_ivar[:,1]
-    TT.comp_shapeDev_e2_ivar = TT.comp_shapeDev_ivar[:,2]
-    TT.comp_shapeExp_r_ivar  = TT.comp_shapeExp_ivar[:,0]
-    TT.comp_shapeExp_e1_ivar = TT.comp_shapeExp_ivar[:,1]
-    TT.comp_shapeExp_e2_ivar = TT.comp_shapeExp_ivar[:,2]
-    TT.delete_column('dev_shapeDev_ivar')
-    TT.delete_column('exp_shapeExp_ivar')
-    TT.delete_column('comp_shapeDev_ivar')
-    TT.delete_column('comp_shapeExp_ivar')
     return TT,hdr
 
 def _blob_iter(blobslices, blobsrcs, blobs, targetwcs, tims, cat, bands,
@@ -2056,20 +2016,6 @@ def stage_writecat(
     T2.ra_ivar  = T2.ra_ivar .astype(np.float32)
     T2.dec_ivar = T2.dec_ivar.astype(np.float32)
 
-    # Unpack shape columns
-    T2.shapeExp_r  = T2.shapeExp[:,0]
-    T2.shapeExp_e1 = T2.shapeExp[:,1]
-    T2.shapeExp_e2 = T2.shapeExp[:,2]
-    T2.shapeDev_r  = T2.shapeDev[:,0]
-    T2.shapeDev_e1 = T2.shapeDev[:,1]
-    T2.shapeDev_e2 = T2.shapeDev[:,2]
-    T2.shapeExp_r_ivar  = T2.shapeExp_ivar[:,0]
-    T2.shapeExp_e1_ivar = T2.shapeExp_ivar[:,1]
-    T2.shapeExp_e2_ivar = T2.shapeExp_ivar[:,2]
-    T2.shapeDev_r_ivar  = T2.shapeDev_ivar[:,0]
-    T2.shapeDev_e1_ivar = T2.shapeDev_ivar[:,1]
-    T2.shapeDev_e2_ivar = T2.shapeDev_ivar[:,2]
-
     T2.decam_flux[T2.decam_flux_ivar == 0] = 0.
 
     if WISE is not None:
@@ -2199,7 +2145,7 @@ def stage_writecat(
         shapeexp_r='arcsec', shapeexp_r_ivar='1/arcsec^2',
         shapedev_r='arcsec', shapedev_r_ivar='1/arcsec^2')
     # Reformat as list aligned with cols
-    units = [units.get(c, None) for c in cols]
+    units = [units.get(c, '') for c in cols]
 
     # match case to T2.
     cc = T2.get_columns()

--- a/py/legacypipe/survey.py
+++ b/py/legacypipe/survey.py
@@ -765,6 +765,10 @@ Now using the current directory as LEGACY_SURVEY_DIR, but this is likely to fail
             return os.path.join(basedir, 'tractor', brickpre,
                                 'tractor-%s.fits' % brick)
         
+        elif filetype == 'tractor-intermediate':
+            return os.path.join(basedir, 'tractor-i', brickpre,
+                                'tractor-%s.fits' % brick)
+
         elif filetype == 'galaxy-sims':
             return os.path.join(basedir, 'tractor', brickpre,
                                 'galaxy-sims-%s.fits' % brick)

--- a/py/test/runbrick_test.py
+++ b/py/test/runbrick_test.py
@@ -72,8 +72,6 @@ if __name__ == '__main__':
     survey = LegacySurveyData(survey_dir=outdir)
     fn = survey.find_file('tractor', brick='2447p120')
     T = fits_table(fn)
-    T.shapeexp = np.vstack((T.shapeexp_r, T.shapeexp_e1, T.shapeexp_e2)).T
-    T.shapedev = np.vstack((T.shapedev_r, T.shapedev_e1, T.shapedev_e2)).T
     cat = read_fits_catalog(T)
     print('Read catalog:', cat)
     assert(len(cat) == 2)


### PR DESCRIPTION
- write intermediate tractor catalogs whose flux columns are just called "flux", not "decam_flux"
- add format_catalog.py module to convert intermediate catalogs into final catalogs
- call format_catalog from runbrick.py to produce catalogs consistent with DR3, for the moment
- various tidy-ups
