### PR TITLE
Add a KD-tree structure to the survey-CCDs table, to make ccds_touching_wcs way faster

### DIFF
--- a/py/legacypipe/survey.py
+++ b/py/legacypipe/survey.py
@@ -1267,7 +1267,15 @@ Now using the current directory as LEGACY_SURVEY_DIR, but this is likely to fail
         if len(fns):
             # Assume that if >= 1 survey-ccds-*.kd.fits files exist,
             # then we should read all CCDs from there rather than
-            # survey-ccds-*.fits.gz
+            # survey-ccds-*.fits.gz.
+            # This file was created via:
+            # python>> from legacypipe.survey import *
+            # >> survey=LegacySurveyData(survey_dir='/global/cscratch1/sd/desiproc/dr5')
+            # >> ccds = survey.get_ccds()
+            # >> ccds.writeto('/tmp/ccds-dr5.fits')
+            # Astrometry.net's 'startree' program:
+            # > startree -i /tmp/ccds-dr5.fits -o /tmp/dr5.kd -P -k -n ccds
+            # > fitsgetext -i /tmp/dr5.kd -o /tmp/survey-ccds-dr5-kd.fits -e 0 -e 6 -e 1 -e 2 -e 3 -e 4 -e 5
             from astrometry.libkd.spherematch import tree_open, tree_search_radec
 
             # MAGIC number: we'll search a 1-degree radius for CCDs

--- a/py/legacypipe/survey.py
+++ b/py/legacypipe/survey.py
@@ -1275,7 +1275,7 @@ Now using the current directory as LEGACY_SURVEY_DIR, but this is likely to fail
             # >> ccds.writeto('/tmp/ccds-dr5.fits')
             # Astrometry.net's 'startree' program:
             # > startree -i /tmp/ccds-dr5.fits -o /tmp/dr5.kd -P -k -n ccds
-            # > fitsgetext -i /tmp/dr5.kd -o /tmp/survey-ccds-dr5-kd.fits -e 0 -e 6 -e 1 -e 2 -e 3 -e 4 -e 5
+            # > fitsgetext -i /tmp/dr5.kd -o /tmp/survey-ccds-dr5.kd.fits -e 0 -e 6 -e 1 -e 2 -e 3 -e 4 -e 5
             from astrometry.libkd.spherematch import tree_open, tree_search_radec
 
             # MAGIC number: we'll search a 1-degree radius for CCDs


### PR DESCRIPTION
* if survey-ccds-*.kd.fits exist, read those file(s) as Astrometry.net/libkd KD-tree structures, and search for and read only nearby CCDs in survey.ccds_touching_wcs().
