### PR TITLE
update modules files for DR5 production

### DIFF
--- a/bin/modulefiles/cori/legacysurvey
+++ b/bin/modulefiles/cori/legacysurvey
@@ -23,5 +23,6 @@ module-whatis "Sets up $product/$version in your environment."
 #set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr3/
 #set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr3-mosaic+bok
 #set PRODUCT_DIR /project/projectdirs/cosmo/work/legacysurvey/dr3
-set PRODUCT_DIR /project/projectdirs/cosmo/work/legacysurvey/dr3
+#set PRODUCT_DIR /project/projectdirs/cosmo/work/legacysurvey/dr3
+set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr5
 setenv LEGACY_SURVEY_DIR $PRODUCT_DIR

--- a/bin/modulefiles/cori/unwise_coadds
+++ b/bin/modulefiles/cori/unwise_coadds
@@ -24,12 +24,8 @@ module-whatis "Sets up $product/$version in your environment."
 # Set environment
 #
 # set PRODUCT_DIR /scratch1/scratchdirs/ameisner/unwise-coadds/fulldepth_sv:/scratch1/scratchdirs/desiproc/unwise-coadds
-#set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr4/unwise-coadds/fulldepth:/global/cscratch1/sd/desiproc/dr4/unwise-coadds/w3w4
-set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr4/unwise-coadds/fulldepth:/global/cscratch1/sd/desiproc/dr4/unwise-coadds/w3w4
+# set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr4/unwise-coadds/fulldepth:/global/cscratch1/sd/desiproc/dr4/unwise-coadds/w3w4
+# set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr4/unwise-coadds/fulldepth:/global/cscratch1/sd/desiproc/dr4/unwise-coadds/w3w4
+set PRODUCT_DIR /global/cscratch1/sd/desiproc/unwise-coadds/fulldepth:/global/cscratch1/sd/desiproc/unwise-coadds/w3w4
 setenv [string toupper $product]_DIR $PRODUCT_DIR
 setenv unwise_coadds_VERSION $version
-
-
- 
-
-

--- a/bin/modulefiles/cori/unwise_coadds_timeresolved
+++ b/bin/modulefiles/cori/unwise_coadds_timeresolved
@@ -22,10 +22,12 @@ module-whatis "Sets up $product/$version in your environment."
 #
 
 # set PRODUCT_DIR /scratch1/scratchdirs/ameisner/unwise-coadds/time_resolved_dr3
-set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr4/unwise-coadds/time_resolved_neo2
+# set PRODUCT_DIR /global/cscratch1/sd/desiproc/dr4/unwise-coadds/time_resolved_neo2
+set PRODUCT_DIR /global/cscratch1/sd/desiproc/unwise-coadds/time_resolved_neo2
 
 # setenv UNWISE_COADDS_TIMERESOLVED_INDEX /project/projectdirs/cosmo/work/wise/outputs/merge/time_resolved_neo1-atlas.fits
-setenv UNWISE_COADDS_TIMERESOLVED_INDEX /global/cscratch1/sd/desiproc/dr4/unwise-coadds/time_resolved_neo2/time_resolved_neo2-atlas.fits
+# setenv UNWISE_COADDS_TIMERESOLVED_INDEX /global/cscratch1/sd/desiproc/dr4/unwise-coadds/time_resolved_neo2/time_resolved_neo2-atlas.fits
+setenv UNWISE_COADDS_TIMERESOLVED_INDEX /global/cscratch1/sd/desiproc/unwise-coadds/time_resolved_neo2/time_resolved_neo2-atlas.fits
 
 setenv [string toupper $product]_DIR $PRODUCT_DIR
 setenv unwise_coadds_timeresolved_VERSION $version


### PR DESCRIPTION
This updates the `LEGACY_SURVEY_DIR` for DR5 production and also updates the default location of the unwise module files in the desiproc scratch space.
