### PR TITLE
SLURM_JOB_ID gets the SLURM job ID on both Cori and Edison; was showi…

### DIFF
--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -3142,7 +3142,7 @@ def main(args=None):
         print('Args:', args)
     print()
     print('Slurm cluster:', os.environ.get('SLURM_CLUSTER_NAME', 'none'))
-    print('Job id:', os.environ.get('JOB_ID', 'none'))
+    print('Job id:', os.environ.get('SLURM_JOB_ID', 'none'))
     print('Array task id:', os.environ.get('ARRAY_TASK_ID', 'none'))
     print()
 

--- a/py/legacypipe/survey.py
+++ b/py/legacypipe/survey.py
@@ -201,7 +201,7 @@ def get_version_header(program_name, survey_dir, git_version=None):
                         comment='Machine where runbrick.py was run'))
     hdr.add_record(dict(name='NERSC', value=os.environ.get('NERSC_HOST', 'none'),
                         comment='NERSC machine where runbrick.py was run'))
-    hdr.add_record(dict(name='JOB_ID', value=os.environ.get('JOB_ID', 'none'),
+    hdr.add_record(dict(name='JOB_ID', value=os.environ.get('SLURM_JOB_ID', 'none'),
                         comment='SLURM job id'))
     hdr.add_record(dict(name='ARRAY_ID', value=os.environ.get('ARRAY_TASK_ID', 'none'),
                         comment='SLURM job array id'))


### PR DESCRIPTION
…ng up as none in DR5 EDR which was run on Cori