### PR TITLE
bug in get_tractor_image()

### DIFF
--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -367,7 +367,6 @@ class LegacySurveyImage(object):
         '''
         Returns x0,x1,y0,y1,slc
         '''
-        slc = None
         imh,imw = self.get_image_shape()
         x0,y0 = 0,0
         x1 = x0 + imw


### PR DESCRIPTION
@dstndstn, what do you think?

I deleted a single line.

The bug is in the get_image_extent() function, which get_tractor_image relies on. Because the top of the func hardcoded "slc=None", the FULL ccd image is returned no matter what "slc" is asked for.

I found it when using your **amazing** create_testcase.py module. The image cutouts for full size CCDs not the 200x200 pixel region I was requesting. Eventually traced it to the above issue. I got the expected create_testcase results after deleting the above line...

