### PR TITLE
Update data scripts to use desiconda

### DIFF
--- a/bin/dr6-envs.sh
+++ b/bin/dr6-envs.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# setting up the environment variables for running the sweeps and external matching
+# section of the pipeline for existing DR6 data
+# see 
+# https://github.com/legacysurvey/legacypipe/blob/master/doc/cookbook.md#sweeps-and-external-matching
+
+set -x
+export ATP_ENABLED=0
+
+outdir=$CSCRATCH/dr6-out
+# for new DRs, this line may need to be changed to the work directory rather than the
+# data dir.
+drdir=/global/projecta/projectdirs/cosmo/data/legacysurvey/dr6
+
+export LEGACYPIPE_DIR=/global/cscratch1/sd/desiproc/DRcode/legacypipe
+
+export TRACTOR_INDIR=$drdir/tractor
+export BRICKSFILE=$drdir/survey-bricks.fits.gz
+export TRACTOR_FILELIST=$outdir/tractor_filelist
+export SWEEP_OUTDIR=$outdir/sweep
+export PYTHONPATH=$LEGACYPIPE_DIR/py:${PYTHONPATH}
+
+export EXTERNAL_OUTDIR=$CSCRATCH/$dr/external
+export SDSSDIR=/global/projecta/projectdirs/sdss/data/sdss
+
+set +x
+
+/usr/bin/mkdir -p $outdir
+/usr/bin/mkdir -p $EXTERNAL_OUTDIR
+/usr/bin/mkdir -p $SWEEP_OUTDIR
+
+if ! [ -f $TRACTOR_FILELIST ]; then
+    find $TRACTOR_INDIR -name 'tractor-*.fits' > $TRACTOR_FILELIST
+else
+    echo $TRACTOR_FILELIST already exists.
+    echo run the following command to rebuild the list of tractor tiles
+    echo "find $TRACTOR_INDIR -name 'tractor-*.fits' > $TRACTOR_FILELIST"
+fi
+

--- a/bin/dr6-envs.sh
+++ b/bin/dr6-envs.sh
@@ -5,13 +5,17 @@
 # see 
 # https://github.com/legacysurvey/legacypipe/blob/master/doc/cookbook.md#sweeps-and-external-matching
 
+# this file serves as a template; use in the sweep match jobs scripts.
+
+# `source` this file (e.g. source dr6-envs.sh). Do not run it with bash.
+
 set -x
 export ATP_ENABLED=0
 
-outdir=$CSCRATCH/dr6-out
-# for new DRs, this line may need to be changed to the work directory rather than the
+# for new DRs, these lines may need to be changed to the work directory rather than the
 # data dir.
 drdir=/global/projecta/projectdirs/cosmo/data/legacysurvey/dr6
+outdir=$CSCRATCH/dr6-out
 
 export LEGACYPIPE_DIR=/global/cscratch1/sd/desiproc/DRcode/legacypipe
 

--- a/bin/generate-sweep-files.slurm
+++ b/bin/generate-sweep-files.slurm
@@ -11,13 +11,19 @@
 set -x
 export ATP_ENABLED=0
 
-# faster python start-up
-module load python/3.5-anaconda
-source /usr/common/contrib/bccp/python-mpi-bcast/nersc/activate.sh
+# FIXME: always update this to the dr being processed.
+source dr6-envs.sh
+
+source /project/projectdirs/desi/software/desi_environment.sh
+
+# avoid potential MKL thread oversubscribing
+export OMP_NUM_THREADS=1
 
 export PYTHONPATH=$LEGACYPIPE_DIR/py:${PYTHONPATH}                                                                                    
+export NUMPROC=$(($SLURM_CPUS_ON_NODE / 2))
 
 # use python-mpi. 'python' from anaconda fails with libpython.so.0.1 not found
 # error when ran via aprun, at least on ~yfeng1's environments.
-time srun -u --cpu_bind=no -n 1 python-mpi $LEGACYPIPE_DIR/bin/generate-sweep-files.py -v --numproc 24 \
+time srun -u --cpu_bind=no -n 1 python $LEGACYPIPE_DIR/bin/generate-sweep-files.py -v \
+        --numproc $NUMPROC \
      -I -f fits -F $TRACTOR_FILELIST --schema blocks -d $BRICKSFILE $TRACTOR_INDIR $SWEEP_OUTDIR

--- a/bin/generate-sweep-files.slurm
+++ b/bin/generate-sweep-files.slurm
@@ -22,8 +22,6 @@ export OMP_NUM_THREADS=1
 export PYTHONPATH=$LEGACYPIPE_DIR/py:${PYTHONPATH}                                                                                    
 export NUMPROC=$(($SLURM_CPUS_ON_NODE / 2))
 
-# use python-mpi. 'python' from anaconda fails with libpython.so.0.1 not found
-# error when ran via aprun, at least on ~yfeng1's environments.
 time srun -u --cpu_bind=no -n 1 python $LEGACYPIPE_DIR/bin/generate-sweep-files.py -v \
         --numproc $NUMPROC \
      -I -f fits -F $TRACTOR_FILELIST --schema blocks -d $BRICKSFILE $TRACTOR_INDIR $SWEEP_OUTDIR

--- a/bin/match-external-catalog.slurm
+++ b/bin/match-external-catalog.slurm
@@ -11,33 +11,35 @@
 set -x
 export ATP_ENABLED=0
 
-# faster python start-up
-module load python/3.5-anaconda
-source /usr/common/contrib/bccp/python-mpi-bcast/nersc/activate.sh
+# FIXME: always update this to the dr being processed.
+source dr6-envs.sh
+source /project/projectdirs/desi/software/desi_environment.sh
+
+# avoid potential MKL thread oversubscribing
+export OMP_NUM_THREADS=1
 
 export PYTHONPATH=$LEGACYPIPE_DIR/py:${PYTHONPATH}                                                                                    
-# use python-mpi. 'python' from anaconda fails with libpython.so.0.1 not found
-# error when ran via aprun, at least on ~yfeng1's environments.
+export NUMPROC=$(($SLURM_CPUS_ON_NODE / 2))
 
-time srun -u --cpu_bind=no -N 1 python-mpi $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc 24 \
+time srun -u --cpu_bind=no -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc $NUMPROC \
      -f fits -F $TRACTOR_FILELIST \
      /global/projecta/projectdirs/sdss/data/sdss/dr12/boss/qso/DR12Q/DR12Q.fits \
      $TRACTOR_INDIR \
      $EXTERNAL_OUTDIR/survey-$dr-dr12Q.fits --copycols MJD PLATE FIBERID RERUN_NUMBER 
 
-time srun -u --cpu_bind=no -N 1 python-mpi $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc 24 \
+time srun -u --cpu_bind=no -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc $NUMPROC \
      -f fits -F $TRACTOR_FILELIST \
      /global/project/projectdirs/cosmo/staging/sdss/dr7/dr7qso.fit.gz \
      $TRACTOR_INDIR \
      $EXTERNAL_OUTDIR/survey-$dr-dr7Q.fits --copycols SMJD PLATE FIBER RERUN 
 
-time srun -u --cpu_bind=no -N 1 python-mpi $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc 24 \
+time srun -u --cpu_bind=no -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc $NUMPROC \
      -f fits -F $TRACTOR_FILELIST \
      /global/projecta/projectdirs/sdss/data/sdss/dr12/boss/qso/DR12Q/Superset_DR12Q.fits \
      $TRACTOR_INDIR \
      $EXTERNAL_OUTDIR/survey-$dr-superset-dr12Q.fits --copycols MJD PLATE FIBERID 
 
-time srun -u --cpu_bind=no -N 1 python-mpi $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc 24 \
+time srun -u --cpu_bind=no -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py -v --numproc $NUMPROC \
      -f fits -F $TRACTOR_FILELIST \
      /global/projecta/projectdirs/sdss/data/sdss/dr14/sdss/spectro/redux/specObj-dr14.fits \
      $TRACTOR_INDIR \


### PR DESCRIPTION
The Python from desiconda is sufficiently good for these applications. Switching to desiconda offloads the toolchain maintenance to desi collaboration.

This PR also adds the environment template (dr6-envs.sh) to the scripts, following the documentation in docs/ directory.

The next DR could simply make a fork of the file, change the paths in the envs, and update the jobs scripts to use the new one.