### PR TITLE
Improved handling of Tycho-2 and Gaia DR2 reference stars

### DIFF
--- a/py/legacypipe/format_catalog.py
+++ b/py/legacypipe/format_catalog.py
@@ -155,7 +155,10 @@ def format_catalog(T, hdr, primhdr, allbands, outfn,
             ('astrometric_n_obs_al', np.int16),
             ('astrometric_n_good_obs_al', np.int16),
             ('astrometric_weight_al', np.float32),
-            ('duplicated_source', bool),]
+            ('duplicated_source', bool),
+            ('a_g_val', np.float32),
+            ('e_bp_min_rp_val', np.float32),
+        ]
         tcols = T.get_columns()
         for c,t in gaia_cols:
             gc = 'gaia_' + c

--- a/py/legacypipe/format_catalog.py
+++ b/py/legacypipe/format_catalog.py
@@ -129,6 +129,7 @@ def format_catalog(T, hdr, primhdr, allbands, outfn,
         
     # Column ordering...
     cols = ['release', 'brickid', 'brickname', 'objid', 'brick_primary', 
+            'brightstarinblob',
             'type', 'ra', 'dec', 'ra_ivar', 'dec_ivar',
             'bx', 'by', 'dchisq', 'ebv', 'mjd_min', 'mjd_max',
             'ref_cat', 'ref_id']

--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -676,6 +676,8 @@ class LegacySurveyImage(object):
         '''
         print('Reading data quality image', self.dqfn, 'ext', self.hdu)
         dq = self._read_fits(self.dqfn, self.hdu, **kwargs)
+
+        # FIXME - Turn SATUR on edges to EDGE
         return dq
 
     def remap_dq(self, dq, header):

--- a/py/legacypipe/oneblob.py
+++ b/py/legacypipe/oneblob.py
@@ -26,7 +26,7 @@ def one_blob(X):
     if X is None:
         return None
     (nblob, iblob, Isrcs, brickwcs, bx0, by0, blobw, blobh, blobmask, timargs,
-     srcs, bands, plots, ps, simul_opt, use_ceres, hastycho, rex) = X
+     srcs, bands, plots, ps, simul_opt, use_ceres, hasbright, rex) = X
 
     print('Fitting blob number', nblob, 'val', iblob, ':', len(Isrcs),
           'sources, size', blobw, 'x', blobh, len(timargs), 'images')
@@ -65,7 +65,7 @@ def one_blob(X):
     B.blob_nimages= np.zeros(len(B), np.int16) + len(timargs)
     
     ob = OneBlob('%i'%(nblob+1), blobwcs, blobmask, timargs, srcs, bands,
-                 plots, ps, simul_opt, use_ceres, hastycho, rex)
+                 plots, ps, simul_opt, use_ceres, hasbright, rex)
     ob.run(B)
 
     B.blob_totalpix = np.zeros(len(B), np.int32) + ob.total_pix
@@ -79,9 +79,9 @@ def one_blob(X):
     assert(len(B.finished_in_blob) == len(B))
     assert(len(B.finished_in_blob) == len(B.started_in_blob))
 
-    B.tycho2inblob = np.zeros(len(B), bool)
-    if hastycho:
-        B.tycho2inblob[:] = True
+    B.brightstarinblob = np.zeros(len(B), bool)
+    if hasbright:
+        B.brightstarinblob[:] = True
 
     B.cpu_blob = np.zeros(len(B), np.float32)
     t1 = time.clock()
@@ -92,7 +92,7 @@ def one_blob(X):
 
 class OneBlob(object):
     def __init__(self, name, blobwcs, blobmask, timargs, srcs, bands,
-                 plots, ps, simul_opt, use_ceres, hastycho, rex):
+                 plots, ps, simul_opt, use_ceres, hasbright, rex):
         self.name = name
         self.rex = rex
         self.blobwcs = blobwcs
@@ -103,7 +103,7 @@ class OneBlob(object):
         self.ps = ps
         self.simul_opt = simul_opt
         self.use_ceres = use_ceres
-        self.hastycho = hastycho
+        self.hasbright = hasbright
         self.deblend = False
         self.tims = self.create_tims(timargs)
         self.total_pix = sum([np.sum(t.getInvError() > 0) for t in self.tims])
@@ -309,11 +309,11 @@ class OneBlob(object):
             src = cat[srci]
             print('Model selection for source %i of %i in blob %s' %
                   (numi+1, len(Ibright), self.name))
-            if isinstance(src, GaiaSource):
-                print('Gaia source', src)
-                if src.isForcedPointSource():
-                    print('Gaia source is forced to be a point source -- not doing model selection.')
-                    continue
+            # if isinstance(src, GaiaSource):
+            #     print('Gaia source', src)
+            #     if src.isForcedPointSource():
+            #         print('Gaia source is forced to be a point source -- not doing model selection.')
+            #         continue
             cpu0 = time.clock()
     
             # Add this source's initial model back in.
@@ -488,11 +488,18 @@ class OneBlob(object):
             else:
                 simname = 'simple'
                 
-            trymodels = ('ptsrc', ptsrc)
-                
+            trymodels = [('ptsrc', ptsrc)]
+
             if oldmodel == 'ptsrc':
-                if self.hastycho:
-                    print('Not computing galaxy models: Tycho-2 star in blob')
+                forced = False
+                if isinstance(src, GaiaSource):
+                    print('Gaia source', src)
+                    if src.isForcedPointSource():
+                        forced = True
+                if forced:
+                    print('Gaia source is forced to be a point source -- not trying other models')
+                elif self.hasbright:
+                    print('Not computing galaxy models: bright star in blob')
                 else:
                     trymodels.append((simname, simple))
                     # Try galaxy models if simple > ptsrc, or if bright.
@@ -599,7 +606,7 @@ class OneBlob(object):
                 if len(self.tims) > 0:
                     _limit_galaxy_stamp_size(newsrc, self.tims[0])
     
-                if self.hastycho:
+                if self.hasbright:
                     modtims = None
                 elif self.bigblob:
                     mods = []
@@ -656,7 +663,7 @@ class OneBlob(object):
                         # self.ps.savefig()
 
                 else:
-                    # Tycho-2 star; set modtractor = srctractor for the ivars
+                    # Bright star; set modtractor = srctractor for the ivars
                     srctractor.setModelMasks(newsrc_mm)
                     modtractor = srctractor
 
@@ -1720,13 +1727,16 @@ def _select_model(chisqs, nparams, galaxy_margin, rex):
 
     if diff < cut:
         return keepmod
-
     # We're going to keep this source!
+
     if rex:
         simname = 'rex'
     else:
         simname = 'simple'
-    
+
+    if not simname in chisqs:
+        # bright stars / reference stars: we don't test the simple model.
+        return 'ptsrc'
     # Now choose between point source and simple model (SIMP/REX)
     if chisqs['ptsrc'] - nparams['ptsrc'] > chisqs[simname] - nparams[simname]:
         #print('Keeping source; PTSRC is better than SIMPLE')

--- a/py/legacypipe/oneblob.py
+++ b/py/legacypipe/oneblob.py
@@ -487,15 +487,17 @@ class OneBlob(object):
                 rex = simple
             else:
                 simname = 'simple'
-            trymodels = [('ptsrc', ptsrc), (simname, simple)]
-    
+                
+            trymodels = ('ptsrc', ptsrc)
+                
             if oldmodel == 'ptsrc':
                 if self.hastycho:
                     print('Not computing galaxy models: Tycho-2 star in blob')
                 else:
+                    trymodels.append((simname, simple))
                     # Try galaxy models if simple > ptsrc, or if bright.
                     # The 'gals' model is just a marker
-                    trymodels.extend([('gals', None)])
+                    trymodels.append(('gals', None))
             else:
                 trymodels.extend([('dev', dev), ('exp', exp), ('comp', comp)])
 

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1709,6 +1709,18 @@ def stage_fitblobs(T=None,
     newcat = BB.sources
     # ... and make the table T parallel with BB.
     T.cut(II)
+    assert(len(T) == len(BB))
+
+    # Drop sources that exited the blob as a result of fitting.
+    left_blob = np.logical_and(BB.started_in_blob,
+                               np.logical_not(BB.finished_in_blob))
+    I, = np.nonzero(np.logical_not(left_blob))
+    if len(I) < len(BB):
+        print('Dropping', len(BB)-len(I), 'sources that exited their blobs during fitting')
+    BB.cut(I)
+    T.cut(I)
+    newcat = [newcat[i] for i in I]
+    assert(len(T) == len(BB))
 
     assert(len(T) == len(newcat))
     print('Old catalog:', len(cat))
@@ -1781,8 +1793,6 @@ def stage_fitblobs(T=None,
     del ninblob
 
     # Copy blob results to table T
-    T.left_blob = np.logical_and(BB.started_in_blob,
-                                 np.logical_not(BB.finished_in_blob))
     for k in ['fracflux', 'fracin', 'fracmasked', 'rchisq', 'cpu_source',
               'cpu_blob', 'blob_width', 'blob_height', 'blob_npix',
               'blob_nimages', 'blob_totalpix', 'dchisq', 'brightstarinblob']:

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1161,7 +1161,7 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
                 #tycho.cut(I)
                 gaia.isbright[J] = True
         if len(gaia):
-            refstars = merge_tables([refstars, gaia])
+            refstars = merge_tables([refstars, gaia], columns='fillzero')
 
     # Don't detect new sources where we already have reference stars
     avoid_x = refstars.ibx

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1408,8 +1408,9 @@ def read_tycho2(survey, targetwcs):
                     tycho.tyc3.astype(np.int64))
     tycho.pmra_ivar = 1./tycho.sigma_pm_ra**2
     tycho.pmdec_ivar = 1./tycho.sigma_pm_dec**2
-    tycho.ra_ivar  = 1./(tycho.sigma_ra / np.cos(np.deg2rad(tycho.dec)) / 1000. / 3600.)**2
-    tycho.dec_ivar = 1./(tycho.sigma_dec / 1000. / 3600.)**2
+    tycho.ra_ivar  = 1./(tycho.sigma_ra / np.cos(np.deg2rad(tycho.dec)))**2
+    tycho.dec_ivar = 1./tycho.sigma_dec**2
+
     tycho.rename('pm_ra', 'pmra')
     tycho.rename('pm_dec', 'pmdec')
     tycho.mag = tycho.mag_vt

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1122,26 +1122,6 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
     
     # Read Tycho-2 stars and use as saturated sources.
     tycho = read_tycho2(survey, targetwcs)
-    # add Gaia-style columns
-    # No parallaxes in Tycho-2
-    tycho.parallax = np.zeros(len(tycho), np.float32)
-    # Arrgh, Tycho-2 has separate epoch_ra and epoch_dec.
-    # Move source to the mean epoch.
-    # FIXME -- check this!!
-    tycho.ref_epoch = (tycho.epoch_ra + tycho.epoch_dec) / 2.
-    cosdec = np.cos(np.deg2rad(tycho.dec))
-    tycho.ra  += (tycho.ref_epoch - tycho.epoch_ra ) * tycho.pmra  / 3600. / cosdec
-    tycho.dec += (tycho.ref_epoch - tycho.epoch_dec) * tycho.pmdec / 3600.
-    # Tycho-2 proper motions are in arcsec/yr; Gaia are mas/yr.
-    tycho.pmra  *= 1000.
-    tycho.pmdec *= 1000.
-    # We already cut on John's "isgalaxy" flag
-    tycho.pointsource = np.ones(len(tycho), bool)
-    # phot_g_mean_mag -- for initial brightness of source
-    tycho.phot_g_mean_mag = tycho.mag
-    tycho.delete_column('epoch_ra')
-    tycho.delete_column('epoch_dec')
-    tycho.isbright = np.ones(len(tycho), bool)
     refstars = tycho
 
     # Add Gaia stars
@@ -1423,6 +1403,28 @@ def read_tycho2(survey, targetwcs):
     for c in ['pmra', 'pmdec', 'pmra_ivar', 'pmdec_ivar']:
         X = tycho.get(c)
         X[np.logical_not(np.isfinite(X))] = 0.
+
+    # add Gaia-style columns
+    # No parallaxes in Tycho-2
+    tycho.parallax = np.zeros(len(tycho), np.float32)
+    # Arrgh, Tycho-2 has separate epoch_ra and epoch_dec.
+    # Move source to the mean epoch.
+    # FIXME -- check this!!
+    tycho.ref_epoch = (tycho.epoch_ra + tycho.epoch_dec) / 2.
+    cosdec = np.cos(np.deg2rad(tycho.dec))
+    tycho.ra  += (tycho.ref_epoch - tycho.epoch_ra ) * tycho.pmra  / 3600. / cosdec
+    tycho.dec += (tycho.ref_epoch - tycho.epoch_dec) * tycho.pmdec / 3600.
+    # Tycho-2 proper motions are in arcsec/yr; Gaia are mas/yr.
+    tycho.pmra  *= 1000.
+    tycho.pmdec *= 1000.
+    # We already cut on John's "isgalaxy" flag
+    tycho.pointsource = np.ones(len(tycho), bool)
+    # phot_g_mean_mag -- for initial brightness of source
+    tycho.phot_g_mean_mag = tycho.mag
+    tycho.delete_column('epoch_ra')
+    tycho.delete_column('epoch_dec')
+    tycho.isbright = np.ones(len(tycho), bool)
+
     return tycho
 
 def stage_fitblobs(T=None,

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1349,7 +1349,8 @@ def read_gaia(targetwcs):
 
     for c in ['ra_error', 'dec_error', 'parallax_error', 'pmra_error', 'pmdec_error']:
         gaia.delete_column(c)
-    for c in ['pmra', 'pmdec', 'parallax', 'pmra_ivar', 'pmdec_ivar', 'parallax_ivar']:
+    for c in ['pmra', 'pmdec', 'parallax', 'pmra_ivar', 'pmdec_ivar', 'parallax_ivar',
+              'a_g_val', 'e_bp_min_rp_val']:
         X = gaia.get(c)
         X[np.logical_not(np.isfinite(X))] = 0.
     return gaia

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1226,6 +1226,10 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
                 keep = np.ones(len(tycho), bool)
                 keep[I] = False
                 tycho.cut(I)
+
+        # FIXME - Append the surviving Tycho2 stars to the "Gaia" catalog.
+
+                
         # Don't detect new sources where we already have Gaia stars
         avoid_x.extend(gaia.ibx)
         avoid_y.extend(gaia.iby)
@@ -1259,6 +1263,10 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
         gaiacat = [GaiaSource.from_catalog(g, bands) for g in gaia]
     else:
         Tgaia = fits_table()
+        # FIXME - Create a Gaia-looking catalog.
+
+    # FIXME - Initialize a big-galaxy catalog here--?
+        
 
     # Saturated blobs -- create a source for each, except for those
     # that already have a Tycho-2 (or Gaia) star
@@ -1295,6 +1303,7 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
         # MAGIC mag for a saturated star
         Tsat.mag = np.zeros(len(Tsat), np.float32) + 15.
         #Tsat.ref_cat = np.array(['  ']*len(Tsat))
+        # FIXME - don't do this
         Tsat = merge_tables([tycho, Tsat], columns='fillzero')
     del satyx
         

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -2551,13 +2551,10 @@ def stage_writecat(
 
     # For reference stars, plug in the reference-catalog inverse-variances.
     if 'ref_id' in T.get_columns() and 'ra_ivar' in T.get_columns():
-        print('Ref_ids:', T.ref_id)
-        I, = np.nonzero([r != '  ' for r in T.ref_id])
+        I, = np.nonzero(T.ref_id)
         if len(I):
             T2.ra_ivar [I] = T.ra_ivar[I]
             T2.dec_ivar[I] = T.dec_ivar[I]
-        #print('T2 ref_cat:', T2.ref_cat)
-        #T2.ref_cat = np.array(['  ' if x=='0.0' else x for x in T2.ref_cat]).astype('S2')
 
     print('TT:')
     TT.about()

--- a/py/test/runbrick_test.py
+++ b/py/test/runbrick_test.py
@@ -75,7 +75,8 @@ if __name__ == '__main__':
     T = fits_table(fn)
     assert(len(T) == 2)
     print('Types:', T.type)
-    assert(T.type[0] == 'REX ')
+    # Since there is a Tycho-2 star in the blob, forced to be PSF.
+    assert(T.type[0] == 'PSF ')
     cmd = ('(cd %s && sha256sum -c %s)' %
            (outdir, os.path.join('tractor', '110', 'brick-1102p240.sha256sum')))
     print(cmd)
@@ -98,7 +99,8 @@ if __name__ == '__main__':
     T = fits_table(fn)
     assert(len(T) == 2)
     print('Types:', T.type)
-    assert(T.type[0] == 'SIMP')
+    # Since there is a Tycho-2 star in the blob, forced to be PSF.
+    assert(T.type[0] == 'PSF ')
 
     # Test that we can run splinesky calib if required...
     


### PR DESCRIPTION
- unify Tycho-2 and Gaia reference star handling -- Tycho-2 stars now have their positions nailed down, same as Gaia stars.
- move Gaia stars to the epoch of Tycho-2 before matching
- force all sources within the same blob as a "bright" reference star to be PSF only
- "bright" defined, for now, as Tycho-2
- add "brightstarinblob" to output catalogs
- add reddening columns to output catalogs
- fix units of Tycho-2 RA,Dec uncertainties
