### PR TITLE
return sky model even if subsky=False

### DIFF
--- a/py/legacypipe/detection.py
+++ b/py/legacypipe/detection.py
@@ -32,7 +32,9 @@ def _detmap(X):
 
 def detection_maps(tims, targetwcs, bands, mp):
     # Render the detection maps
+
     H,W = targetwcs.shape
+    H,W = np.int(H), np.int(W)
     ibands = dict([(b,i) for i,b in enumerate(bands)])
 
     detmaps = [np.zeros((H,W), np.float32) for b in bands]

--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -389,14 +389,13 @@ class LegacySurveyImage(object):
                                   primhdr=primhdr, imghdr=imghdr)
         skysig1 = getattr(sky, 'sig1', None)
         
-        midsky = 0.
+        skymod = np.zeros_like(img)
+        sky.addTo(skymod)
+        midsky = np.median(skymod)
         if subsky:
             from tractor.sky import ConstantSky
             print('Instantiating and subtracting sky model')
-            skymod = np.zeros_like(img)
-            sky.addTo(skymod)
             img -= skymod
-            midsky = np.median(skymod)
             zsky = ConstantSky(0.)
             zsky.version = getattr(sky, 'version', '')
             zsky.plver = getattr(sky, 'plver', '')

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -80,6 +80,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
                bands=['g','r','z'],
                do_calibs=True,
                splinesky=True,
+               subsky=True,
                gaussPsf=False, pixPsf=False, hybridPsf=False,
                normalizePsf=False,
                apodize=False,
@@ -112,7 +113,8 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
     Sky:
 
     - *splinesky*: boolean.  Use SplineSky model, rather than ConstantSky?
-
+    - *subsky*: boolean.  Subtract sky model from tims?
+    
     '''
     from legacypipe.survey import (
         get_git_version, get_version_header, wcs_for_brick, read_one_tim)
@@ -346,6 +348,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
     args = [(im, targetrd, dict(gaussPsf=gaussPsf, pixPsf=pixPsf,
                                 hybridPsf=hybridPsf, normalizePsf=normalizePsf,
                                 splinesky=splinesky,
+                                subsky=subsky,
                                 apodize=apodize,
                                 constant_invvar=constant_invvar,
                                 pixels=read_image_pixels))
@@ -3629,6 +3632,7 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
               rgb_kwargs=None,
               rex=False,
               splinesky=True,
+              subsky=True,
               constant_invvar=False,
               gaia_stars=False,
               min_mjd=None, max_mjd=None,
@@ -3739,6 +3743,8 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
     
     - *splinesky*: boolean; use the splined sky model (default is constant)?
 
+    - *subsky*: boolean; subtract the sky model when reading in tims (tractor images)?
+    
     - *ceres*: boolean; use Ceres Solver when possible?
 
     - *wise_ceres*: boolean; use Ceres Solver for unWISE forced photometry?
@@ -3843,6 +3849,7 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
                   constant_invvar=constant_invvar,
                   depth_cut=depth_cut,
                   splinesky=splinesky,
+                  subsky=subsky,
                   gaia_stars=gaia_stars,
                   min_mjd=min_mjd, max_mjd=max_mjd,
                   simul_opt=simul_opt,


### PR DESCRIPTION
This PR includes a very minor change to `image` to return the (spline) sky model read from disk even if `subsky=False`.  This should have no impact on the pipeline because we *always* use `subsky=True`, but it's helpful for the testing I've been doing.

Second, in `detection.detection_maps` I found that some `wcs` objects returned height and width attributes that were float rather than integer, which causes issues with the subsequent bit of code, so they're explicitly cast as `int` here.

@dstndstn please feel free to reject or alter these changes but it would be good to resolve this PR while it's still fresh in my mind at least!