### PR TITLE
add --no-tycho option and make the large-galaxy magic the default

### DIFF
--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1220,8 +1220,8 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
         sat.ref_cat = np.array(['  '] * len(sat))
         del satyx
         
-        avoid_x = np.append(avoid_x, sat.ibx)
-        avoid_y = np.append(avoid_y, sat.iby)
+        avoid_x.append(sat.ibx)
+        avoid_y.append(sat.iby)
         # Create catalog entries for saturated blobs
         for r,d,m in zip(sat.ra, sat.dec, sat.mag):
             fluxes = dict([(band, NanoMaggies.magToNanomaggies(m))
@@ -1301,6 +1301,7 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
     record_event and record_event('stage_srcs: SED-matched')
     print('Running source detection at', nsigma, 'sigma')
     SEDs = survey.sed_matched_filters(bands)
+
     # Add a ~1" exclusion zone around reference, saturated stars, and large
     # galaxies.
     avoid_r = np.zeros_like(avoid_x) + 4


### PR DESCRIPTION
This PR adds a `--no-tycho` optional input to `runbrick` to turn off the Tycho-2 "forced" stellar fitting, which is useful for some applications (the default is to still use Tycho-2, as usual).  The screenshot below shows (from left to right: data, model, residual) the default behavior (bottom row) and the output of the code using `--no-tycho` (top row).  The biggest difference is the big galaxy on the right-hand-side which is fit as a PSF in the default code because of the Tycho2 star that's just off-screen on the right-hand-side, vs the proper model fit which occurs when using `--no-tycho`.

![screen shot 2019-02-05 at 12 18 01 pm](https://user-images.githubusercontent.com/1431820/52291419-4a238b80-2940-11e9-999c-158b556351ba.png)

I also made the large-galaxy prior fitting the default by changing the previous `--large-galaxies` optional input (which was required to get this behavior) to `--no-large-galaxies`.

Additional minor stylistic tweaks and error catching came along as well.

Tests are crashing but not because of this PR, I'm told by @dstndstn.