### PR TITLE
various pre-DR8 fixes

### DIFF
--- a/py/legacypipe/reference.py
+++ b/py/legacypipe/reference.py
@@ -38,7 +38,7 @@ def get_reference_sources(survey, targetwcs, pixscale, bands,
         gaia = read_gaia(marginwcs)
     if gaia is not None:
         gaia.isbright = np.zeros(len(gaia), bool)
-        gaia.ismedium = np.ones(len(gaia), bool)
+        gaia.ismedium = gaia.pointsource
         # Handle sources that appear in both Gaia and Tycho-2 by dropping the entry from Tycho-2.
         if len(gaia) and len(tycho):
             # Before matching, apply proper motions to bring them to


### PR DESCRIPTION
Opening PR now to track progress; not merge-ready.  This branch can be used to implement issues that the various test reductions reveal, ahead of DR8 production.

This first change here is an attempt to address the over-subtraction of the galaxy here--
  http://legacysurvey.org/viewer-dev?ra=187.7612&dec=12.1816&zoom=15&layer=dr8-test10-resid&bricks&gaia-dr2

As documented on-list, the theory is that this is a medium-bright Gaia source, but not a point source which passes the astrometric excess cut.  In the `master` branch, we allow the background to vary around these kinds of sources, which I *think* leads to this over-subtraction.  The change is to only allow medium-bright Gaia *point sources* to have a floating background.

Will test this change once we have a functioning `survey-ccds` file.