### PR TITLE
Add new DR8 "overlap" test region

### DIFF
--- a/py/legacypipe/queue-calibs.py
+++ b/py/legacypipe/queue-calibs.py
@@ -427,6 +427,9 @@ def main():
     elif opt.region == 'dr8-test-deep2-egs':
         rlo, rhi = 213, 216.5
         dlo, dhi = 52, 54
+    elif opt.region == 'dr8-overlap':
+        rlo, rhi = 132, 140.5, 
+        dlo, dhi = 31.5, 35
         
     if opt.mindec is not None:
         dlo = opt.mindec

--- a/py/legacypipe/queue-calibs.py
+++ b/py/legacypipe/queue-calibs.py
@@ -428,7 +428,7 @@ def main():
         rlo, rhi = 213, 216.5
         dlo, dhi = 52, 54
     elif opt.region == 'dr8-test-overlap':
-        rlo, rhi = 132, 140.5,
+        rlo, rhi = 132, 140.5
         dlo, dhi = 31.5, 35
         
     if opt.mindec is not None:

--- a/py/legacypipe/queue-calibs.py
+++ b/py/legacypipe/queue-calibs.py
@@ -427,7 +427,7 @@ def main():
     elif opt.region == 'dr8-test-deep2-egs':
         rlo, rhi = 213, 216.5
         dlo, dhi = 52, 54
-    elif opt.region == 'dr8-overlap':
+    elif opt.region == 'dr8-test-overlap':
         rlo, rhi = 132, 140.5,
         dlo, dhi = 31.5, 35
         

--- a/py/legacypipe/queue-calibs.py
+++ b/py/legacypipe/queue-calibs.py
@@ -428,7 +428,7 @@ def main():
         rlo, rhi = 213, 216.5
         dlo, dhi = 52, 54
     elif opt.region == 'dr8-overlap':
-        rlo, rhi = 132, 140.5, 
+        rlo, rhi = 132, 140.5,
         dlo, dhi = 31.5, 35
         
     if opt.mindec is not None:


### PR DESCRIPTION
Add a new area to the DR8 test regions that includes overlap between DECaLS, MzLS and BASS.