### PR TITLE
increase matching radius for external catalogs to 1.5

### DIFF
--- a/bin/match-external-catalog.py
+++ b/bin/match-external-catalog.py
@@ -227,7 +227,7 @@ def parse_args():
     ap.add_argument('-f', "--format", choices=['fits', 'hdf5'], nargs='+', default=["fits"],
         help="Format of the output file")
 
-    ap.add_argument('-t', "--tolerance", default=1, type=float,
+    ap.add_argument('-t', "--tolerance", default=1.5, type=float,
         help="Tolerance of the angular distance for a match, in arcseconds")
 
     ap.add_argument('-F', "--filelist", default=None,


### PR DESCRIPTION
On last Wednesday's telecon it was decided to increase the matching radius for external catalogs to 1.5". This PR does that.

Should address https://github.com/legacysurvey/legacypipe/issues/117.