### PR TITLE
minor updates (improvements!) to how we seed LSLGA sources

### DIFF
--- a/py/legacypipe/reference.py
+++ b/py/legacypipe/reference.py
@@ -300,8 +300,8 @@ def read_large_galaxies(survey, targetwcs):
     # if len(gals) == 0:
     #     return None,None
     galaxies.radius = galaxies.d25 / 2. / 60.
-    # John told me to do this
-    galaxies.radius *= 1.2
+    # John told me to do this...
+    #galaxies.radius *= 1.2 ...and then John taketh away.
     galaxies.delete_column('d25')
     galaxies.rename('lslga_id', 'ref_id')
     galaxies.ref_cat = np.array(['L2'] * len(galaxies))

--- a/py/legacypipe/reference.py
+++ b/py/legacypipe/reference.py
@@ -115,8 +115,8 @@ def get_reference_sources(survey, targetwcs, pixscale, bands,
             elif g.islargegalaxy:
                 fluxes = dict([(band, NanoMaggies.magToNanomaggies(g.mag)) for band in bands])
                 assert(np.all(np.isfinite(list(fluxes.values()))))
-                rr = g.radius * 3600.
-                pa = g.pa
+                rr = g.radius * 3600. / 0.5 # factor of two accounts for R(25)-->reff
+                pa = 180 - g.pa
                 if not np.isfinite(pa):
                     pa = 0.
                 logr, ee1, ee2 = EllipseESoft.rAbPhiToESoft(rr, g.ba, pa)


### PR DESCRIPTION
* Do not embiggen the initial large-galaxy radius by the 20% fudge factor.
* Account for the rough factor of two difference between the R(25) isophotal radius and the half-light radius.
* Rotate the initial position angle from LSLGA by 180 degrees to bring it into the `e1`, `e2` system.

Results compared to dr8b look better!
http://legacysurvey.org/viewer-dev?ra=20.5991&dec=-0.8754&zoom=14&layer=dr8b-decam

<img width="1602" alt="Screen Shot 2019-03-27 at 6 17 50 PM" src="https://user-images.githubusercontent.com/1431820/55116136-c2930700-50bc-11e9-933d-ed775ee7cdaa.png">
