### PR TITLE
Bring unWISE Catalog PSF into legacypipe

### DIFF
--- a/bin/legacypipe-env
+++ b/bin/legacypipe-env
@@ -24,6 +24,6 @@ export LARGEGALAXIES_DIR=/global/project/projectdirs/cosmo/staging/largegalaxies
 
 export PS1CAT_DIR=/global/project/projectdirs/cosmo/work/ps1/cats/chunks-qz-star-v3/
 
-export UNWISE_PSF_DIR=/global/project/projectdirs/cosmo/staging/unwise_psf/2018-11-25
+export UNWISE_PSF_DIR=/global/project/projectdirs/cosmo/staging/unwise_psf/2019-03-27
 export WISE_PSF_DIR=${UNWISE_PSF_DIR}/etc
 export PYTHONPATH=$UNWISE_PSF_DIR/py:$PYTHONPATH

--- a/bin/legacypipe-env
+++ b/bin/legacypipe-env
@@ -24,6 +24,6 @@ export LARGEGALAXIES_DIR=/global/project/projectdirs/cosmo/staging/largegalaxies
 
 export PS1CAT_DIR=/global/project/projectdirs/cosmo/work/ps1/cats/chunks-qz-star-v3/
 
-export UNWISE_PSF_DIR=/global/project/projectdirs/cosmo/staging/unwise_psf/2019-03-27
+export UNWISE_PSF_DIR=/global/project/projectdirs/cosmo/staging/unwise_psf/dr8
 export WISE_PSF_DIR=${UNWISE_PSF_DIR}/etc
 export PYTHONPATH=$UNWISE_PSF_DIR/py:$PYTHONPATH

--- a/py/legacypipe/unwise.py
+++ b/py/legacypipe/unwise.py
@@ -230,8 +230,12 @@ def unwise_forcedphot(cat, tiles, band=1, roiradecbox=None,
 
         if pixelized_psf:
             import unwise_psf
-            psfimg = unwise_psf.get_unwise_psf(band, tile.coadd_id, 
-                                               modelname='unwisecat')
+            if (band == 1) or (band == 2):
+                # we only have updated PSFs for W1 and W2
+                psfimg = unwise_psf.get_unwise_psf(band, tile.coadd_id, 
+                                                   modelname='neo4_unwisecat')
+            else:
+                psfimg = unwise_psf.get_unwise_psf(band, tile.coadd_id)
             #print('PSF postage stamp', psfimg.shape, 'sum', psfimg.sum())
 
             if band == 4:
@@ -268,7 +272,7 @@ def unwise_forcedphot(cat, tiles, band=1, roiradecbox=None,
 
             from tractor.psf import PixelizedPSF
             psfimg /= psfimg.sum()
-            fluxrescales = {1: 1.050, 2: 0.997, 3: 1.0, 4: 1.0}
+            fluxrescales = {1: 1.04, 2: 1.005, 3: 1.0, 4: 1.0}
             psfimg *= fluxrescales[band]
             tim.psf = PixelizedPSF(psfimg)
             #print('### HACK ### normalized PSF to 1.0')

--- a/py/legacypipe/unwise.py
+++ b/py/legacypipe/unwise.py
@@ -230,7 +230,8 @@ def unwise_forcedphot(cat, tiles, band=1, roiradecbox=None,
 
         if pixelized_psf:
             import unwise_psf
-            psfimg = unwise_psf.get_unwise_psf(band, tile.coadd_id)
+            psfimg = unwise_psf.get_unwise_psf(band, tile.coadd_id, 
+                                               modelname='unwisecat')
             #print('PSF postage stamp', psfimg.shape, 'sum', psfimg.sum())
 
             if band == 4:
@@ -267,6 +268,8 @@ def unwise_forcedphot(cat, tiles, band=1, roiradecbox=None,
 
             from tractor.psf import PixelizedPSF
             psfimg /= psfimg.sum()
+            fluxrescales = {1: 1.050, 2: 0.997, 3: 1.0, 4: 1.0}
+            psfimg *= fluxrescales[band]
             tim.psf = PixelizedPSF(psfimg)
             #print('### HACK ### normalized PSF to 1.0')
             print('Set PSF to', tim.psf)


### PR DESCRIPTION
This brings the unWISE Catalog NEO4 PSF into legacypipe.  It also adds a modest arbitrary adjustment to the PSF normalization to bring the catalog's overall flux scale into agreement with unWISE.  Note that there is a small non-linearity so it's impossible to do this perfectly at all magnitudes.

This PR requires that unwise_psf also be updated to a recent version (i.e., since ~yesterday).  Otherwise unwise_psf.get_unwise_psf will not support the 'modelname' argument.