### PR TITLE
add unwise_modelsky_dir to output header(s) and as optional input to run_brick

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
          name: Pip packages
          command: |
-            for x in setuptools wheel intel-numpy intel-scipy psycopg2 fitsio matplotlib astropy photutils zmq; do pip3 install $x; done
+            for x in setuptools wheel intel-numpy intel-scipy psycopg2-binary fitsio matplotlib astropy photutils zmq; do pip3 install $x; done
             rm -Rf /root/.cache/pip
       - run:
           name: Dust maps

--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -1589,7 +1589,7 @@ def validate_procdate_plver(fn, filetype, expnum, plver, procdate,
                     print('WARNING: {} {}!={} in {} header but old_calibs_ok=True'.format(key, val, targetval, fn))
                     continue
                 else:
-                    print('WARNING: {} {}!={} in {} header'.format(key val, targetval, fn))
+                    print('WARNING: {} {}!={} in {} header'.format(key, val, targetval, fn))
                     return False
         return True
 

--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -838,7 +838,7 @@ class LegacySurveyImage(object):
 
             if not os.path.exists(self.splineskyfn):
                 if self.merged_splineskyfn is not None:
-                    raise RuntimeError('Read Splinesky: neither {} nor {} found'.format(self.merged_splineskyfn, self.splineskyfn))
+                    raise RuntimeError('Merged splinesky model {} not found'.format(self.merged_splineskyfn))
                 return None
 
         fn = self.skyfn
@@ -942,7 +942,7 @@ class LegacySurveyImage(object):
                 psf = self.read_merged_psfex_model(normalizePsf=normalizePsf, old_calibs_ok=old_calibs_ok)
             else:
                 if not os.path.exists(self.psffn):
-                    raise RuntimeError('Read Splinesky: neither {} nor {} found'.format(self.merged_psffn, self.psffn))
+                    raise RuntimeError('Merged PsfEx model {} not found'.format(self.merged_psffn))
 
         if psf is None:
             debug('Reading PsfEx model from', self.psffn)
@@ -1586,10 +1586,10 @@ def validate_procdate_plver(fn, filetype, expnum, plver, procdate,
                 val = val.strip()
             if val != targetval:
                 if old_calibs_ok:
-                    print('WARNING: {}!={} in {} header but old_calibs_ok=True'.format(val, targetval, fn))
+                    print('WARNING: {} {}!={} in {} header but old_calibs_ok=True'.format(key, val, targetval, fn))
                     continue
                 else:
-                    print('WARNING: {}!={} in {} header'.format(val, targetval, fn))
+                    print('WARNING: {} {}!={} in {} header'.format(key val, targetval, fn))
                     return False
         return True
 

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -83,6 +83,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
                record_event=None,
                unwise_dir=None,
                unwise_tr_dir=None,
+               unwise_modelsky_dir=None,
                **kwargs):
     '''
     This is the first stage in the pipeline.  It
@@ -156,7 +157,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
     version_header = get_version_header(program_name, survey.survey_dir, release,
                                         git_version=gitver)
 
-    deps = get_dependency_versions(unwise_dir, unwise_tr_dir)
+    deps = get_dependency_versions(unwise_dir, unwise_tr_dir, unwise_modelsky_dir)
     for name,value,comment in deps:
         version_header.add_record(dict(name=name, value=value, comment=comment))
 
@@ -2351,6 +2352,7 @@ def stage_wise_forced(
     brickname=None,
     unwise_dir=None,
     unwise_tr_dir=None,
+    unwise_modelsky_dir=None,
     brick=None,
     wise_ceres=True,
     unwise_coadds=False,
@@ -2387,12 +2389,6 @@ def stage_wise_forced(
     # use Aaron's WISE pixelized PSF model (unwise_psf repository)?
     wpixpsf = True
 
-    # use Eddie's WISE Catalog background maps?
-    background_dir = os.path.join(survey.get_calib_dir(), 'wise', 'modelsky')
-    if not os.path.exists(background_dir):
-        print('WARNING: no WISE backgrounds in', background_dir)
-        background_dir = None
-
     # Create list of groups-of-tiles to photometer
     args = []
     # Skip if $UNWISE_COADDS_DIR or --unwise-dir not set.
@@ -2402,7 +2398,7 @@ def stage_wise_forced(
         for band in [1,2,3,4]:
             get_masks = targetwcs if (band == 1) else None
             args.append((wcat, wtiles, band, roiradec,
-                         wise_ceres, wpixpsf, unwise_coadds, get_masks, ps, True, background_dir))
+                         wise_ceres, wpixpsf, unwise_coadds, get_masks, ps, True, unwise_modelsky_dir))
 
     # Add time-resolved WISE coadds
     # Skip if $UNWISE_COADDS_TIMERESOLVED_DIR or --unwise-tr-dir not set.
@@ -2456,7 +2452,7 @@ def stage_wise_forced(
                 eptiles.unwise_dir = np.array([os.path.join(tdir, 'e%03i'%ep)
                                               for ep in epochs[I,ie]])
                 eargs.append((ie,(wcat, eptiles, band, roiradec,
-                                  wise_ceres, wpixpsf, False, None, ps, False, background_dir)))
+                                  wise_ceres, wpixpsf, False, None, ps, False, unwise_modelsky_dir)))
 
     # Run the forced photometry!
     record_event and record_event('stage_wise_forced: photometry')
@@ -2851,6 +2847,7 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
               wise_ceres=True,
               unwise_dir=None,
               unwise_tr_dir=None,
+              unwise_modelsky_dir=None,
               threads=None,
               plots=False, plots2=False, coadd_bw=False,
               plot_base=None, plot_number=0,
@@ -2864,8 +2861,7 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
               prereqs_update=None,
               stagefunc = None,
               ):
-    '''
-    Run the full Legacy Survey data reduction pipeline.
+    '''Run the full Legacy Survey data reduction pipeline.
 
     The pipeline is built out of "stages" that run in sequence.  By
     default, this function will cache the result of each stage in a
@@ -2967,6 +2963,10 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
     - *unwise_tr_dir*: string; where to look for time-resolved
       unWISE coadd files.  This may be a colon-separated list of
       directories to search in order.
+
+    - *unwise_modelsky_dir*: string; where to look for the unWISE sky background
+      maps.  The default is to look in the "wise/modelsky" subdirectory of the
+      calibration directory.
 
     - *threads*: integer; how many CPU cores to use
 
@@ -3076,6 +3076,7 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
                   lanczos=lanczos,
                   unwise_dir=unwise_dir,
                   unwise_tr_dir=unwise_tr_dir,
+                  unwise_modelsky_dir=unwise_modelsky_dir,
                   plots=plots, plots2=plots2, coadd_bw=coadd_bw,
                   force=forceStages, write=write_pickles,
                   record_event=record_event)
@@ -3428,6 +3429,7 @@ def get_runbrick_kwargs(survey=None,
                         stage=[],
                         unwise_dir=None,
                         unwise_tr_dir=None,
+                        unwise_modelsky_dir=None,
                         write_stage=None,
                         write=True,
                         gpsf=False,
@@ -3489,7 +3491,12 @@ def get_runbrick_kwargs(survey=None,
         unwise_dir = os.environ.get('UNWISE_COADDS_DIR', None)
     if unwise_tr_dir is None:
         unwise_tr_dir = os.environ.get('UNWISE_COADDS_TIMERESOLVED_DIR', None)
-    opt.update(unwise_dir=unwise_dir, unwise_tr_dir=unwise_tr_dir)
+    if unwise_modelsky_dir is None:
+        unwise_modelsky_dir = os.path.join(survey.get_calib_dir(), 'wise', 'modelsky')
+        if not os.path.exists(unwise_modelsky_dir):
+            print('WARNING: no WISE sky background maps in {}'.format(unwise_modelsky_dir))
+            unwise_modelsky_dir = None
+    opt.update(unwise_dir=unwise_dir, unwise_tr_dir=unwise_tr_dir, unwise_modelsky_dir=unwise_modelsky_dir)
 
     # list of strings if -w / --write-stage is given; False if
     # --no-write given; True by default.

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -3496,6 +3496,8 @@ def get_runbrick_kwargs(survey=None,
         if not os.path.exists(unwise_modelsky_dir):
             print('WARNING: no WISE sky background maps in {}'.format(unwise_modelsky_dir))
             unwise_modelsky_dir = None
+        else:
+            unwise_modelsky_dir = os.path.realpath(unwise_modelsky_dir) # follow the soft link
     opt.update(unwise_dir=unwise_dir, unwise_tr_dir=unwise_tr_dir, unwise_modelsky_dir=unwise_modelsky_dir)
 
     # list of strings if -w / --write-stage is given; False if

--- a/py/legacypipe/survey.py
+++ b/py/legacypipe/survey.py
@@ -442,7 +442,7 @@ def get_version_header(program_name, survey_dir, release, git_version=None):
 
     return hdr
 
-def get_dependency_versions(unwise_dir, unwise_tr_dir):
+def get_dependency_versions(unwise_dir, unwise_tr_dir, unwise_modelsky_dir):
     depvers = []
     headers = []
     # Get DESICONDA version, and read file $DESICONDA/pkg_list.txt for
@@ -499,6 +499,11 @@ def get_dependency_versions(unwise_dir, unwise_tr_dir):
         # this is assumed to be only a single directory
         headers.append(('UNWISTD', unwise_tr_dir, ''))
         #headers.append(('UNWISTD', unwise_tr_dir, 'unWISE time-resolved dir'))
+
+    if unwise_modelsky_dir is not None:
+        depvers.append(('unwise_modelsky', unwise_modelsky_dir))
+        # this is assumed to be only a single directory
+        headers.append(('UNWISSKY', unwise_modelsky_dir, ''))
 
     added_long = False
     for i,(name,value) in enumerate(depvers):

--- a/py/legacypipe/unwise.py
+++ b/py/legacypipe/unwise.py
@@ -19,7 +19,7 @@ def unwise_forcedphot(cat, tiles, band=1, roiradecbox=None,
                       pixelized_psf=False,
                       get_masks=None,
                       move_crpix=False,
-                      background_dir=None):
+                      modelsky_dir=None):
     '''
     Given a list of tractor sources *cat*
     and a list of unWISE tiles *tiles* (a fits_table with RA,Dec,coadd_id)
@@ -106,8 +106,8 @@ def unwise_forcedphot(cat, tiles, band=1, roiradecbox=None,
             realwcs.set_crpix(x+dx, y+dy)
             print('CRPIX', x,y, 'shift by', dx,dy, 'to', realwcs.crpix)
 
-        if background_dir and band in [1, 2]:
-            fn = os.path.join(background_dir, '%s.%i.mod.fits' % (tile.coadd_id, band))
+        if modelsky_dir and band in [1, 2]:
+            fn = os.path.join(modelsky_dir, '%s.%i.mod.fits' % (tile.coadd_id, band))
             if not os.path.exists(fn):
                 raise RuntimeError('WARNING: does not exist:', fn)
             x0,x1,y0,y1 = tim.roi
@@ -511,10 +511,10 @@ def unwise_phot(X):
     This is the entry-point from runbrick.py, called via mp.map()
     '''
     (wcat, tiles, band, roiradec, wise_ceres, pixelized_psf, get_mods, get_masks, ps,
-     move_crpix, background_dir) = X
+     move_crpix, modelsky_dir) = X
     kwargs = dict(roiradecbox=roiradec, band=band, pixelized_psf=pixelized_psf,
                   get_masks=get_masks, ps=ps, move_crpix=move_crpix,
-                  background_dir=background_dir)
+                  modelsky_dir=modelsky_dir)
     if get_mods:
         kwargs.update(get_models=get_mods)
 


### PR DESCRIPTION
Addresses #320.  Still testing; not quite ready to merge.

Note that previously this directory variable was called `background_dir`, which I changed to `unwise_modelsky_dir` to match the other unWISE directories (static + time-resolved stacks).