### PR TITLE
Add patching in of ucal zero points to update_ccd_cuts.py, and better handle izY ccd_cuts

### DIFF
--- a/bin/update_ccd_cuts.py
+++ b/bin/update_ccd_cuts.py
@@ -279,6 +279,50 @@ def good_ccd_fraction(survey, ccds):
     return ngoodccds/float(nccds)
 
 
+def match(a, b):
+    sa = numpy.argsort(a)
+    sb = numpy.argsort(b)
+    ua = numpy.unique(a[sa])
+    if len(ua) != len(a):# or len(ub) != len(b):
+        raise ValueError('All keys in a must be unique.')
+    ind = numpy.searchsorted(a[sa], b)
+    m = (ind >= 0) & (ind < len(a))
+    matches = a[sa[ind[m]]] == b[m]
+    m[m] &= matches
+    return sa[ind[m]], numpy.flatnonzero(m)
+
+
+def patch_zeropoints(zps, ccds, ccdsa):
+    if not numpy.all((ccds.image_hdu == ccdsa.image_hdu) &
+                     (ccdsa.image_filename == ccdsa.image_filename)):
+        raise ValueError('ccds and ccdsa must be row matched!')
+    mreplace = ccds.dec < -29.25
+    mok = ((zps.scatter > 0) & (zps.scatter < 0.05) & 
+           (numpy.abs(zps.resid) < 0.2))
+    mz, mc = match(zps.mjd_obs, ccds.mjd_obs)
+    m = mok[mz] & mreplace[mc]
+    mz = mz[m]
+    mc = mc[m]
+    oldccdzpt = ccds.ccdzpt.copy()
+    ccds.zpt[mc] = (zps.zp-zps.resid)[mz]
+    ccds.ccdzpt[mc] = (zps.zp-zps.resid)[mz]
+    ccds.ccdphrms[mc] = zps.scatter[mz]
+    ccdsa.zpt[mc] = (zps.zp-zps.resid)[mz]
+    ccdsa.ccdzpt[mc] = (zps.zp-zps.resid)[mz]
+    ccdsa.ccdphrms[mc] = zps.scatter[mz]
+    oldzp = numpy.where(oldccdzpt[mc] != 0, oldccdzpt[mc], 22.5)
+    newzp = numpy.where(ccds.ccdzpt[mc] != 0, ccds.ccdzpt[mc], 22.5)
+    oldzpscale = 10.**((oldzp-22.5)/2.5)
+    newzpscale = 10.**((newzp-22.5)/2.5)
+    ccds.sig1[mc] = ccds.sig1[mc]*oldzpscale/newzpscale
+    ccdsa.sig1[mc] = ccdsa.sig1[mc]*oldzpscale/newzpscale
+    dzp = newzp-oldzp
+    ccdsa.psfdepth[mc] += dzp
+    ccdsa.gausspsfdepth[mc] += dzp
+    ccdsa.galdepth[mc] += dzp
+    ccdsa.gaussgaldepth[mc] += dzp
+
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(
@@ -291,17 +335,29 @@ if __name__ == "__main__":
                         help='ccds-annotated file name')
     parser.add_argument('survey-ccds-out', type=str, default='',
                         help='output survey-ccds file')
+    parser.add_argument('ccds-annotated-out', type=str, default='',
+                        help='output annotated-ccds file')
     parser.add_argument('--tilefile', type=str, default='',
                         help='appropriate tile file for survey')
     parser.add_argument('--imlist', type=str, default='',
                         help='image list for survey, needed for 90prime')
     parser.add_argument('--image2coadd', type=str, default='',
                         help='list of DES good exposures')
+    parser.add_argument('--zeropoints', type=str, default='',
+                        help='ucal zero points for declination < -29.25')
     args = parser.parse_args()
     ccds = fits_table(getattr(args, 'survey-ccds'))
+    annotated = fits_table(getattr(args, 'ccds-annotated'))
+    if numpy.any((ccds.image_filename != annotated.image_filename) |
+                 (ccds.image_hdu != annotated.image_hdu)):
+        raise ValueError('survey and annotated CCDs files must be row-matched!')
     if not numpy.all(ccds.ccd_cuts == 0):
         print('Warning: zeroing existing ccd_cuts')
         ccds.ccd_cuts = 0.
+    if len(args.zeropoints) > 0:
+        zp = fits_table(args.zeropoints)
+        patch_zeropoints(zp, ccds, annotated)
+
     from legacyzpts import psfzpt_cuts
     from pkg_resources import resource_filename
     fn = resource_filename('legacyzpts', 
@@ -310,7 +366,6 @@ if __name__ == "__main__":
     psfzpt_cuts.add_psfzpt_cuts(ccds, args.camera, bad_expid, 
                                 image2coadd=args.image2coadd)
 
-    annotated = fits_table(getattr(args, 'ccds-annotated'))
     depthbit = psfzpt_cuts.CCD_CUT_BITS['depth_cut']
     manybadbit = psfzpt_cuts.CCD_CUT_BITS['too_many_bad_ccds']
     if not numpy.all((ccds.ccd_cuts & depthbit) == 0):
@@ -321,4 +376,6 @@ if __name__ == "__main__":
     dcut = depthcut(args.camera, ccds, annotated, tilefile=args.tilefile,
                     imlist=args.imlist)
     ccds.ccd_cuts = ccds.ccd_cuts | (depthbit * ~dcut)
+    annotated.ccd_cuts = ccds.ccd_cuts
     ccds.write_to(getattr(args, 'survey-ccds-out'))
+    annotated.writeto(getattr(args, 'ccds-annotated-out'))

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -222,7 +222,12 @@ def write_survey_table(T, surveyfn, camera=None, bad_expid=None):
     T.cd2_1 = T.cd2_1.astype(np.float32)
     T.cd2_2 = T.cd2_2.astype(np.float32)
 
-    add_psfzpt_cuts(T, camera, bad_expid)
+    # add_psfzpt_cuts(T, camera, bad_expid)
+    # We now run this as a separate step at the end via
+    # update_ccd_cuts.
+    # replace with placeholder that masks everything until this is run.
+    from legacyzpts import psfzpt_cuts
+    T.ccd_cuts = psfzpt_cuts.CCD_CUT_BITS['err_legacyzpts']
 
     writeto_via_temp(surveyfn, T)
     print('Wrote %s' % surveyfn)

--- a/py/legacyzpts/psfzpt_cuts.py
+++ b/py/legacyzpts/psfzpt_cuts.py
@@ -107,7 +107,9 @@ def detrend_decam_zeropoints(P):
     airmass_terms = [
         ('g', 0.173),
         ('r', 0.090),
-        ('z', 0.060),]
+        ('i', 0.054),
+        ('z', 0.060),
+        ('Y', 0.058)]
 
     mjd_terms = [
         ('g', 25.08, [
@@ -126,6 +128,7 @@ def detrend_decam_zeropoints(P):
             ( 950.0, 1250.0, 25.350, 25.260, 25.635,  -3.0000e-04),
             (1250.0, 1650.0, 25.320, 25.240, 25.570,  -2.0000e-04),
             (1650.0, 1900.0, 25.440, 25.380, 25.836,  -2.4001e-04),]),
+        ('i', 25.26, []),
         ('z', 24.92, [
             (   0.0,  160.0, 24.970, 24.970, 24.970,   0.0000e+00),
             ( 160.0,  480.0, 25.030, 24.950, 25.070,  -2.5000e-04),
@@ -134,7 +137,9 @@ def detrend_decam_zeropoints(P):
             ( 950.0, 1150.0, 25.030, 24.880, 25.743,  -7.5001e-04),
             (1150.0, 1270.0, 24.880, 25.030, 23.442,   1.2500e-03),
             (1270.0, 1650.0, 25.030, 24.890, 25.498,  -3.6842e-04),
-            (1650.0, 1900.0, 25.070, 24.940, 25.928,  -5.2000e-04),]),]
+            (1650.0, 1900.0, 25.070, 24.940, 25.928,  -5.2000e-04),]),
+        ('Y', 23.87, []),
+    ]
 
     return detrend_zeropoints(P, airmass_terms, mjd_terms)
 
@@ -222,7 +227,7 @@ def psf_zeropoint_cuts(P, pixscale,
         ccdzpt = detrend_mzlsbass_zeropoints(P)
 
     cuts = [
-        ('not_grz',   np.array([f.strip() not in keys for f in P.filter])),
+        ('not_grz',   np.array([f.strip() not in 'grz' for f in P.filter])),
         ('ccdnmatch', P.ccdnphotom < 20),
         ('zpt_small', np.array([zpt < zpt_cut_lo.get(f.strip(),0) for f,zpt in zip(P.filter, ccdzpt)])),
         ('zpt_large', np.array([zpt > zpt_cut_hi.get(f.strip(),0) for f,zpt in zip(P.filter, ccdzpt)])),
@@ -301,17 +306,21 @@ def add_psfzpt_cuts(T, camera, bad_expid, image2coadd=''):
         # https://github.com/legacysurvey/legacypipe/blob/dr5.0/py/legacypipe/decam.py#L50
         g0 = 25.08
         r0 = 25.29
-        #i0 = 25.26
+        i0 = 25.26
         z0 = 24.92
+        Y0 = 23.87
         dg = (-0.5, 0.25)
-        #di = (-0.5, 0.25)
+        di = (-0.5, 0.25)
         dr = (-0.5, 0.25)
         dz = (-0.5, 0.25)
+        dY = (-0.5, 0.25)
         radec_rms = 0.4
         skybright = dict(g=90., r=150., z=180.)
         zpt_diff_avg = 0.25
-        zpt_lo = dict(g=g0+dg[0], r=r0+dr[0], z=z0+dz[0])#, i=i0+dr[0])
-        zpt_hi = dict(g=g0+dg[1], r=r0+dr[1], z=z0+dz[1])#, i=i0+dr[1])
+        zpt_lo = dict(g=g0+dg[0], r=r0+dr[0], z=z0+dz[0], i=i0+di[0],
+                      Y=Y0+dY[0])
+        zpt_hi = dict(g=g0+dg[1], r=r0+dr[1], z=z0+dz[1], i=i0+di[1],
+                      Y=Y0+dY[1])
         psf_zeropoint_cuts(T, pixscale, zpt_lo, zpt_hi, bad_expid, camera, radec_rms,
                            skybright, zpt_diff_avg, image2coadd=image2coadd)
     else:


### PR DESCRIPTION
This PR updates update_ccd_cuts.py to optionally patch in ubercal zero points, if a new --zeropoints argument is given.  Then the CCD_CUTS are updated given those new zero points.  Additionally, sig1 and the various depth fields are updated accordingly in the survey & annotated CCDs files.  

This PR also updates the handling of izY CCD_CUTS.  Previously these filters were given dummy nominal zero points of 0 in psfzpt_cuts.py, leading all good exposures to have CCD_CUTS of at least zpt_large.  Since the depth cut bit & too many bad CCDs bits have the annoying property of excluding everything that has been excluded for any other reason, these bits are also set.  This PR fixes at least the zero point issue by updating psfzpt_cuts.py to have more realistic values for nominal i and Y zero points.  i & Y CCDs still have not_grz set, however, so they are still masked by CCD_CUTS and then additionally get masked by too_many_bad_ccds and depth_cut.

I have verified that this PR produces files with identical zero points, sig1, and depths to the existing CCDs files.  The CCD_CUTS are of course different.  In izY, all cases of different CCD_CUTS are due to zpt_large vs. zpt_small being fixed.  There are 4 g band and 6 z band exposures that also get different CCD_CUTS to the existing files.  These are all south of dec = -30.  My suspicion is that they were caused by the fact that the previous depth cut operated on image depths that had not been updated with the ubercal zero points, so I do not plan on trying to track down these cases further.  

For the current DR8 run, I have manually patched over these 10 cases so that the previous and current CCDs files make the identical CCD_CUTS selections for all grz images.  The manually patched file is here:
/global/cscratch1/sd/schlafly/ccds/survey-ccds-decam-dr8-allpatch.fits
/global/cscratch1/sd/schlafly/ccds/ccds-annotated-decam-dr8-allpatch.fits