### PR TITLE
No individual survey-ccds files.

### DIFF
--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -2132,6 +2132,8 @@ def runit(imgfn, photomfn, surveyfn, annfn, mp, bad_expid=None,
                        bad_expid=bad_expid)
     # survey --> annotated
     create_annotated_table(surveyfn, annfn, measureargs['camera'], survey, mp)
+    # Remove survey file
+    os.remove(surveyfn)
 
     t0 = ptime('write-results-to-fits',t0)
     
@@ -2273,6 +2275,8 @@ def main(image_list=None,args=None):
 
         if leg_ok and ann_ok and phot_ok and psf_ok and sky_ok:
             print('Already finished: {}'.format(F.annfn))
+            if leg_ok:
+                os.remove(F.surveyfn)
             continue
 
         if leg_ok and phot_ok and not ann_ok:

--- a/py/legacyzpts/legacy_zeropoints_merge.py
+++ b/py/legacyzpts/legacy_zeropoints_merge.py
@@ -71,7 +71,7 @@ def fix_hdu_post(tab):
     return tab
         
 
-if __name__ == "__main__":
+def main(args):
     parser = argparse.ArgumentParser(description='Generate a legacypipe-compatible CCDs file from a set of reduced imaging.')
     parser.add_argument('--file_list',help='List of zeropoint fits files to concatenate')
     parser.add_argument('--nproc',type=int,default=1,help='number mpi tasks')
@@ -81,7 +81,8 @@ if __name__ == "__main__":
     parser.add_argument('--cut', action='store_true',default=False, help='Cut to ccd_cuts==0')
     parser.add_argument('--cut-expnum', action='store_true',default=False, help='Cut out rows with expnum==0')
     parser.add_argument('files', nargs='*', help='Zeropoint files to concatenate')
-    opt = parser.parse_args()
+ 
+    opt = parser.parse_args(args)
     
     fns = np.array(opt.files)
     if opt.file_list:
@@ -144,3 +145,8 @@ if __name__ == "__main__":
             cats.image_filename = np.array(fns)
         write_cat(cats, outname=opt.outname)
         print("Done")
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1:])
+

--- a/py/legacyzpts/merge_annotated.py
+++ b/py/legacyzpts/merge_annotated.py
@@ -1,0 +1,126 @@
+from legacyzpts import legacy_zeropoints_merge
+from astrometry.util.fits import fits_table
+import argparse
+
+"""
+Merges the ccds-annnotated files and generate a survey-ccds file as an after-burner.
+Uses the following naming convention:
+    ccds-annotated-<camera>-<drN>.fits
+    survey-ccds-<camera>-<drN>.fits
+where camera and the DR number are inputs.
+Note that there are no checks on whether the input file list consists of annotated files.
+
+M. Landriau, September 2019
+"""
+
+if __name__ == "__main__":
+    parser0 = argparse.ArgumentParser(description='Generates an annotated CCDs file and a legacypipe-compatible CCDs file from a set of reduced imaging.')
+    parser0.add_argument('--file_list',help='List of zeropoint fits files to concatenate')
+    parser0.add_argument('--camera', type=str, help='decam, mosaic or 90prime')
+    parser0.add_argument('--data_release', type=int, help='Number of LS DR')
+    opt = parser0.parse_args()
+
+    fna = "ccds-annotated-"+opt.camera+"-dr"+str(opt.data_release)+".fits"
+    fns = fna.replace("ccds-annotated", "survey-ccds")
+
+    arg1 = "--file_list"
+    arg2 = "--outname"
+
+    legacy_zeropoints_merge.main([arg1, opt.file_list, arg2, fna])
+
+    # List of keys to cut to
+    """
+    keys = ['image_filename',
+            'image_hdu',
+            'camera  ',
+            'expnum  ',
+            'plver   ',
+            'procdate',
+            'plprocid',
+            'ccdname ',
+            'object  ',
+            'propid  ',
+            'filter  ',
+            'exptime ',
+            'mjd_obs ',
+            'airmass ',
+            'fwhm    ',
+            'width   ',
+            'height  ',
+            'ra_bore ',
+            'dec_bore',
+            'crpix1  ',
+            'crpix2  ',
+            'crval1  ',
+            'crval2  ',
+            'cd1_1   ',
+            'cd1_2   ',
+            'cd2_1   ',
+            'cd2_2   ',
+            'yshift  ',
+            'ra      ',
+            'dec     ',
+            'skyrms  ',
+            'sig1    ',
+            'ccdzpt  ',
+            'zpt     ',
+            'ccdraoff',
+            'ccddecoff',
+            'ccdskycounts',
+            'ccdskysb',
+            'ccdrarms',
+            'ccddecrms',
+            'ccdphrms',
+            'ccdnastrom',
+            'ccdnphotom',
+            'ccd_cuts']
+        """
+    keys = ['image_filename',
+            'image_hdu',
+            'camera',
+            'expnum',
+            'plver',
+            'procdate',
+            'plprocid',
+            'ccdname',
+            'object',
+            'propid',
+            'filter',
+            'exptime',
+            'mjd_obs',
+            'airmass',
+            'fwhm',
+            'width',
+            'height',
+            'ra_bore',
+            'dec_bore',
+            'crpix1',
+            'crpix2',
+            'crval1',
+            'crval2',
+            'cd1_1',
+            'cd1_2',
+            'cd2_1',
+            'cd2_2',
+            'yshift',
+            'ra',
+            'dec',
+            'skyrms',
+            'sig1',
+            'ccdzpt',
+            'zpt',
+            'ccdraoff',
+            'ccddecoff',
+            'ccdskycounts',
+            'ccdskysb',
+            'ccdrarms',
+            'ccddecrms',
+            'ccdphrms',
+            'ccdnastrom',
+            'ccdnphotom',
+            'ccd_cuts']
+
+    t = fits_table(fna)
+    t.writeto(fns, columns=keys)
+
+


### PR DESCRIPTION
This PR fixes #430

A new merging code uses the naming convention for a given camera and data release and calls the old code with appropriate options.

The individual survey-ccds file is still output, as a checkpoint, and is removed after the annotated file is written out.