### PR TITLE
Newnamecals

### DIFF
--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -162,10 +162,10 @@ class LegacySurveyImage(object):
         calibdir = self.survey.get_calib_dir() + "/" + tmpname.replace(basename,"")
         calname = basename+"-"+self.ccdname
         self.name = calname
-        self.sefn = os.path.join(calibdir, basename, calname+"-se.fits")
-        self.psffn = os.path.join(calibdir, basename, calname+"-psfex.fits")
-        self.skyfn = os.path.join(calibdir, basename, calname+"-sky.fits")
-        self.splineskyfn = os.path.join(calibdir, basename, calname+"-splinesky.fits")
+        self.sefn = os.path.join(calibdir, basename, basename+"-se-"+self.ccdname+".fits")
+        self.psffn = os.path.join(calibdir, basename, basename+"-psfex-"+self.ccdname+".fits")
+        self.skyfn = os.path.join(calibdir, basename, basename+"-sky-"+self.ccdname+".fits")
+        self.splineskyfn = os.path.join(calibdir, basename, basename+"-splinesky-"+self.ccdname+".fits")
         self.merged_psffn = os.path.join(calibdir, basename+"-psfex.fits")
         self.merged_splineskyfn = os.path.join(calibdir, basename+"-splinesky.fits")
 

--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -142,6 +142,7 @@ class LegacySurveyImage(object):
         self.pixscale = 3600. * np.sqrt(np.abs(ccd.cd1_1 * ccd.cd2_2 -
                                                ccd.cd1_2 * ccd.cd2_1))
 
+        """
         expstr = '%08i' % self.expnum
         self.name = '%s-%s-%s' % (self.camera, expstr, self.ccdname)
         calname = '%s/%s/%s-%s-%s' % (expstr[:5], expstr, self.camera,
@@ -155,6 +156,18 @@ class LegacySurveyImage(object):
                                          '%s-%s.fits' % (self.camera, expstr))
         self.merged_splineskyfn = os.path.join(calibdir, 'splinesky-merged', expstr[:5],
                                                '%s-%s.fits' % (self.camera, expstr))
+        """
+        tmpname = self.image_filename.replace(".fits.fz", "")
+        basename = tmpname.split('/')[-1]
+        calibdir = self.survey.get_calib_dir() + "/" + tmpname.replace(basename,"")
+        calname = basename+"-"+self.ccdname
+        self.name = calname
+        self.sefn = os.path.join(calibdir, basename, calname+"-se.fits")
+        self.psffn = os.path.join(calibdir, basename, calname+"-psfex.fits")
+        self.skyfn = os.path.join(calibdir, basename, calname+"-sky.fits")
+        self.splineskyfn = os.path.join(calibdir, basename, calname+"-splinesky.fits")
+        self.merged_psffn = os.path.join(calibdir, basename+"-psfex.fits")
+        self.merged_splineskyfn = os.path.join(calibdir, basename+"-splinesky.fits")
 
     def compute_filenames(self):
         # Compute data quality and weight-map filenames

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -1101,15 +1101,30 @@ class Measurer(object):
         return ps1.median[:, ps1band] + np.clip(colorterm, -1., +1.)
 
     def get_splinesky_merged_filename(self):
+        """
         expstr = '%08i' % self.expnum
         fn = os.path.join(self.calibdir, self.camera, 'splinesky-merged', expstr[:5],
-                          '%s-%s.fits' % (self.camera, expstr))
+                          '%s-%s.fits' % (self.camera, expstr)
+        """
+        basefn = os.path.basename(self.fn_base)
+        basedir = os.path.dirname(self.fn_base)
+        base = basefn.split('.')[0]
+        fn0 = base+"-splinesky.fits"
+        fn = os.path.join(self.calibdir, basedir, fn0)
         return fn
 
     def get_splinesky_unmerged_filename(self):
+        """
         expstr = '%08i' % self.expnum
         return os.path.join(self.calibdir, self.camera, 'splinesky', expstr[:5], expstr,
                             '%s-%s-%s.fits' % (self.camera, expstr, self.ext))
+        """
+        basefn = os.path.basename(self.fn_base)
+        basedir = os.path.dirname(self.fn_base)
+        base = basefn.split('.')[0]
+        fn0 = base+"-splinesky-"+self.ext+".fits"
+        fn = os.path.join(self.calibdir, basedir, base, fn0)
+        return fn
 
     def get_splinesky(self):
         # Find splinesky model file and read it
@@ -1315,15 +1330,30 @@ class Measurer(object):
         return cal
 
     def get_psfex_merged_filename(self):
+        """
         expstr = '%08i' % self.expnum
         fn = os.path.join(self.calibdir, self.camera, 'psfex-merged', expstr[:5],
                           '%s-%s.fits' % (self.camera, expstr))
+        """
+        basefn = os.path.basename(self.fn_base)
+        basedir = os.path.dirname(self.fn_base)
+        base = basefn.split('.')[0]
+        fn0 = base+"-psfex.fits"
+        fn = os.path.join(self.calibdir, basedir, fn0)
         return fn
 
     def get_psfex_unmerged_filename(self):
+        """
         expstr = '%08i' % self.expnum
         return os.path.join(self.calibdir, self.camera, 'psfex', expstr[:5], expstr,
                           '%s-%s-%s.fits' % (self.camera, expstr, self.ext))
+        """
+        basefn = os.path.basename(self.fn_base)
+        basedir = os.path.dirname(self.fn_base)
+        base = basefn.split('.')[0]
+        fn0 = base+"-psfex-"+self.ext+".fits"
+        fn = os.path.join(self.calibdir, basedir, base, fn0)
+        return fn
 
     def get_psfex_model(self):
         import tractor
@@ -1963,6 +1993,7 @@ def measure_image(img_fn, mp, image_dir='images', run_calibs_only=False,
             raise RuntimeError('Merged psfex file did not validate!')
         # At this point the merged file exists and has been validated, so remove
         # the individual PSFEx and SE files.
+        os.system("pwd")
         for ext in extlist:
             measure.ext = ext
             psffn = measure.get_psfex_unmerged_filename()
@@ -1971,6 +2002,16 @@ def measure_image(img_fn, mp, image_dir='images', run_calibs_only=False,
             sefn = psffn.replace('psfex', 'se')
             if os.path.isfile(sefn):
                 os.remove(sefn)
+
+    # Remove temporary individual files directory
+    basefn = os.path.basename(img_fn)
+    basedir = os.path.dirname(img_fn)
+    base = basefn.split('.')[0]
+    tmpdir = os.path.join(measure.calibdir, basedir, base)
+    try:
+        os.rmdir(tmpdir)
+    except OSError:
+        pass
 
     if run_calibs_only:
         return
@@ -2032,9 +2073,14 @@ class outputFns(object):
         self.imgfn = imgfn
         self.image_dir = image_dir
 
+        """
         # Keep the last directory component
         dirname = os.path.basename(os.path.dirname(self.imgfn))
         basedir = os.path.join(outdir, camera, dirname)
+        """
+        # Keep same path structure as the images
+        dirname = os.path.dirname(self.imgfn)
+        basedir = os.path.join(outdir, dirname)
         trymakedirs(basedir)
 
         basename = os.path.basename(self.imgfn) 


### PR DESCRIPTION
This PR has two linked components:
- legacyzpts outputs the calibrations and zeropoints with the new names in the new directory structure.
- legacypipe reads in the calibrations in this new scheme.

Note that legacyzeropoints hasn't been fully tested: as I seem to have a problem with sextractor and psfex.  splinesky is output and merged properly and if the merged PSF file is present, it proceeds with the cleanup.
