### PR TITLE
Mark duplicate raw exposure as bad

### DIFF
--- a/py/legacyzpts/data/90prime-bad_expid.txt
+++ b/py/legacyzpts/data/90prime-bad_expid.txt
@@ -110,3 +110,4 @@
 77890081 blobby/donutty PSF triggers CRs
 77890078 blobby/donutty PSF triggers CRs
 79650061 blobby/donutty PSF triggers CRs
+75140200 weird duplicate image


### PR DESCRIPTION
This commit marks the single duplicate raw exposure as bad.  See
https://github.com/legacysurvey/legacypipe/issues/398
for details.  On disk file name is
CP20160505/ksb_160506_123748_ooi_g_ls9.fits.fz