### PR TITLE
Make ccdphrms more restrictive

### DIFF
--- a/py/legacyzpts/psfzpt_cuts.py
+++ b/py/legacyzpts/psfzpt_cuts.py
@@ -11,7 +11,7 @@ def psf_cuts_to_string(ccd_cuts, join=', '):
             s.append(k)
     return join.join(s)
 
-# Bit codes for why a CCD got cut, used in cut_ccds().gg
+# Bit codes for why a CCD got cut, used in cut_ccds().
 CCD_CUT_BITS= dict(
     err_legacyzpts = 0x1,
     not_grz = 0x2,

--- a/py/legacyzpts/psfzpt_cuts.py
+++ b/py/legacyzpts/psfzpt_cuts.py
@@ -11,7 +11,7 @@ def psf_cuts_to_string(ccd_cuts, join=', '):
             s.append(k)
     return join.join(s)
 
-# Bit codes for why a CCD got cut, used in cut_ccds().
+# Bit codes for why a CCD got cut, used in cut_ccds().gg
 CCD_CUT_BITS= dict(
     err_legacyzpts = 0x1,
     not_grz = 0x2,
@@ -231,7 +231,7 @@ def psf_zeropoint_cuts(P, pixscale,
         ('ccdnmatch', P.ccdnphotom < 20),
         ('zpt_small', np.array([zpt < zpt_cut_lo.get(f.strip(),0) for f,zpt in zip(P.filter, ccdzpt)])),
         ('zpt_large', np.array([zpt > zpt_cut_hi.get(f.strip(),0) for f,zpt in zip(P.filter, ccdzpt)])),
-        ('phrms',     P.ccdphrms > 0.2),
+        ('phrms',     P.ccdphrms > 0.05),
         ('exptime', P.exptime < 30),
         ('seeing_bad', np.logical_not(np.logical_and(seeing > 0, seeing < 3.0))),
         ('badexp_file', np.array([expnum in bad_expid for expnum in P.expnum])),


### PR DESCRIPTION
CCDPHRMS is the scatter in the LS photometry relative to PS1 for bright stars after removal of a zero point offset.  Currently we throw out CCDs where this is larger than 0.2 mag.  That's a ton; if there are unknown things messing with our photometry at the 20% level, I'm concerned.  This PR proposes moving that to 0.05 mag.

In DR8 I checked that that removed something like ~0.7% of objects.  This needs to be rechecked for DR9.  It's also probably worth checking that all of the CCDs aren't in ~globular clusters or something.  But this PR is intended to record this issue.