### PR TITLE
Changes to bitmasks and headers

### DIFF
--- a/py/legacypipe/format_catalog.py
+++ b/py/legacypipe/format_catalog.py
@@ -129,7 +129,7 @@ def format_catalog(T, hdr, primhdr, allbands, outfn, release,
                 T.set(c, np.zeros(len(T), np.float32))
 
     if gaia_tagalong:
-        gaia_cols = [#('source_id', np.int64),  # already have this in ref_id
+        gaia_cols = [
             ('pointsource', bool),  # did we force it to be a point source?
             ('phot_g_mean_mag', np.float32),
             ('phot_g_mean_flux_over_error', np.float32),
@@ -184,7 +184,9 @@ def format_catalog(T, hdr, primhdr, allbands, outfn, release,
                   'apflux_ivar', 'apflux_masked']:
             add_fluxlike(c)
 
+    wise_apflux = False
     if has_wise and has_ap and 'apflux_w1' in T.get_columns():
+        wise_apflux = True
         add_wiselike('apflux')
         add_wiselike('apflux_resid')
         add_wiselike('apflux_ivar')
@@ -289,12 +291,25 @@ def format_catalog(T, hdr, primhdr, allbands, outfn, release,
     arcsec = 'arcsec'
     flux = 'nanomaggy'
     fluxiv = '1/nanomaggy^2'
+    pm = 'mas/yr'
+    pmiv = '1/(mas/yr)^2'
     units = dict(
         ra=deg, dec=deg, ra_ivar=degiv, dec_ivar=degiv, ebv='mag',
         shape_r=arcsec, shape_r_ivar='1/arcsec^2')
+    if motions:
+        units.update(pmra=pm, pmdec=pm, pmra_ivar=pmiv, pmdec_ivar=pmiv,
+                     parallax='mas', parallax_ivar='1/mas^2')
+    if gaia_tagalong:
+        units.update(gaia_phot_g_mean_mag='mag',
+                     gaia_phot_bp_mean_mag='mag',
+                     gaia_phot_rp_mean_mag='mag')
     # WISE fields
     wunits = dict(flux=flux, flux_ivar=fluxiv,
-                  lc_flux=flux, lc_flux_ivar=fluxiv)
+                  lc_flux=flux, lc_flux_ivar=fluxiv,
+                  psfdepth=fluxiv)
+    if wise_apflux:
+        wunits.update(apflux=flux, apflux_resid=flux,
+                      apflux_ivar=fluxiv)
     # Fields that take prefixes (and have bands)
     funits = dict(
         flux=flux, flux_ivar=fluxiv,

--- a/py/legacypipe/format_catalog.py
+++ b/py/legacypipe/format_catalog.py
@@ -114,7 +114,7 @@ def format_catalog(T, hdr, primhdr, allbands, outfn, release,
 
     # Column ordering...
     cols = ['release', 'brickid', 'brickname', 'objid', 'brick_primary',
-            'brightblob', 'maskbits', 'iterative',
+            'maskbits', 'iterative',
             'type', 'ra', 'dec', 'ra_ivar', 'dec_ivar',
             'bx', 'by', 'dchisq', 'ebv', 'mjd_min', 'mjd_max',
             'ref_cat', 'ref_id']

--- a/py/legacypipe/oneblob.py
+++ b/py/legacypipe/oneblob.py
@@ -107,7 +107,6 @@ def one_blob(X):
     B.started_in_blob = blobmask[safe_y0, safe_x0]
     # This uses 'initial' pixel positions, because that's what determines
     # the fitting behaviors.
-    B.brightblob = refmap[safe_y0, safe_x0].astype(np.int16)
     B.cpu_source = np.zeros(len(B), np.float32)
     B.blob_width  = np.zeros(len(B), np.int16) + blobw
     B.blob_height = np.zeros(len(B), np.int16) + blobh
@@ -879,7 +878,6 @@ class OneBlob(object):
         Bnew.blob_symm_width   = np.zeros(len(Bnew), np.int16)
         Bnew.blob_symm_height  = np.zeros(len(Bnew), np.int16)
         Bnew.hit_limit = np.zeros(len(Bnew), bool)
-        Bnew.brightblob = self.refmap[Tnew.iby, Tnew.ibx].astype(np.int16)
         # Be quieter during iterative detection!
         bloblogger = logging.getLogger('legacypipe.oneblob')
         loglvl = bloblogger.getEffectiveLevel()

--- a/py/legacypipe/outliers.py
+++ b/py/legacypipe/outliers.py
@@ -226,12 +226,8 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
                 tim.dq[(mask & maskbits) > 0] |= DQ_BITS['outlier']
 
                 # Write output!
-                # copy version_header before modifying it.
-                hdr = fitsio.FITSHDR()
-                # Plug in the tim WCS header
-                tim.subwcs.add_to_header(hdr)
-                hdr.delete('IMAGEW')
-                hdr.delete('IMAGEH')
+                from legacypipe.utils import copy_header_with_wcs
+                hdr = copy_header_with_wcs(None, tim.subwcs)
                 hdr.add_record(dict(name='IMTYPE', value='outlier_mask',
                                     comment='LegacySurvey image type'))
                 hdr.add_record(dict(name='CAMERA',  value=tim.imobj.camera))

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -2334,9 +2334,9 @@ def stage_writecat(
         maskbits |= w2val * (wise_mask_maps[1] != 0)
 
     hdr = version_header
-    hdr.add_record(dict(name='MB_WISEM1', value=w1val,
+    hdr.add_record(dict(name='MB_WISE1', value=w1val,
                         comment='Maskbit: WISE W1 (all masks)'))
-    hdr.add_record(dict(name='MB_WISEM2', value=w2val,
+    hdr.add_record(dict(name='MB_WISE2', value=w2val,
                         comment='Maskbit: WISE W2 (all masks)'))
 
     revmap = dict([(bit,name) for name,bit in MASKBITS.items()])

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -2340,15 +2340,15 @@ def stage_writecat(
         if not bit in bitmap:
             continue
         version_header.add_record(
-            dict(name='ABIT_%i' % i, value=bitmap[bit],
-                 comment='ALLMASK/ANYMASK bit 2**%i=%i meaning' % (i, bit)))
+            dict(name='AM_%s' % bitmap[bit].upper()[:5], value=bit,
+                 comment='ALLMASK/ANYMASK bit 2**%i' % i))
     for i in range(16):
         bit = 1<<i
         if not bit in bitmap:
             continue
         version_header.add_record(
-            dict(name='AM_%s' % bitmap[bit].upper()[:5], value=bit,
-                 comment='ALLMASK/ANYMASK bit 2**%i' % i))
+            dict(name='ABIT_%i' % i, value=bitmap[bit],
+                 comment='ALLMASK/ANYMASK bit 2**%i=%i meaning' % (i, bit)))
 
     # create maskbits header
     hdr = copy_header_with_wcs(version_header, targetwcs)

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -235,7 +235,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
               'object', getattr(ccd, 'object', '').strip())
 
     tnow = Time()
-    debug('[serial tims] Finding images touching brick:', tnow-tlast)
+    debug('Finding images touching brick:', tnow-tlast)
     tlast = tnow
 
     if do_calibs:
@@ -255,7 +255,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
         args = [(im, kwa) for im in ims]
         mp.map(run_calibs, args)
         tnow = Time()
-        debug('[parallel tims] Calibrations:', tnow-tlast)
+        debug('Calibrations:', tnow-tlast)
         tlast = tnow
 
     # Read Tractor images
@@ -272,7 +272,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None,
     record_event and record_event('stage_tims: done read_tims')
 
     tnow = Time()
-    debug('[parallel tims] Read', len(ccds), 'images:', tnow-tlast)
+    debug('Read', len(ccds), 'images:', tnow-tlast)
     tlast = tnow
 
     # Cut the table of CCDs to match the 'tims' list
@@ -669,7 +669,7 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
     detmaps, detivs, satmaps = detection_maps(tims, targetwcs, bands, mp,
                                               apodize=10)
     tnow = Time()
-    debug('[parallel srcs] Detmaps:', tnow-tlast)
+    debug('Detmaps:', tnow-tlast)
     tlast = tnow
     record_event and record_event('stage_srcs: sources')
 
@@ -730,7 +730,7 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
     assert(len(cat) == len(T))
 
     tnow = Time()
-    debug('[serial srcs] Peaks:', tnow-tlast)
+    debug('Peaks:', tnow-tlast)
     tlast = tnow
 
     if plots:
@@ -796,7 +796,7 @@ def stage_srcs(targetrd=None, pixscale=None, targetwcs=None,
     del hot
 
     tnow = Time()
-    debug('[serial srcs] Blobs:', tnow-tlast)
+    debug('Blobs:', tnow-tlast)
     tlast = tnow
 
     sky_overlap = True
@@ -892,7 +892,7 @@ def stage_fitblobs(T=None,
     T.orig_dec = T.dec.copy()
 
     tnow = Time()
-    debug('[serial fitblobs]:', tnow-tlast)
+    debug('Fitblobs:', tnow-tlast)
     tlast = tnow
 
     # Were we asked to only run a subset of blobs?
@@ -1072,7 +1072,7 @@ def stage_fitblobs(T=None,
 
         debug('Got', n_finished_total, 'results; wrote', len(R), 'to checkpoint')
 
-    debug('[parallel fitblobs] Fitting sources took:', Time()-tlast)
+    debug('Fitting sources:', Time()-tlast)
 
     # Repackage the results from one_blob...
 
@@ -1601,7 +1601,7 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
         ps.savefig()
 
     tnow = Time()
-    debug('[serial coadds]:', tnow-tlast)
+    debug('Coadds:', tnow-tlast)
     tlast = tnow
     # Render model images...
     record_event and record_event('stage_coadds: model images')
@@ -1613,7 +1613,7 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
     del bothmods
 
     tnow = Time()
-    debug('[parallel coadds] Getting model images:', tnow-tlast)
+    debug('Model images:', tnow-tlast)
     tlast = tnow
 
     # Compute source pixel positions
@@ -1886,7 +1886,7 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
         ps.savefig()
 
     tnow = Time()
-    debug('[serial coadds] Aperture photometry, wrap-up', tnow-tlast)
+    debug('Aperture photometry wrap-up:', tnow-tlast)
 
     return dict(T=T, T_donotfit=T_donotfit, apertures_pix=apertures,
                 apertures_arcsec=apertures_arcsec,

--- a/py/legacypipe/utils.py
+++ b/py/legacypipe/utils.py
@@ -163,6 +163,7 @@ def read_primary_header(fn):
     return fitsio.read_header(fn)
 
 def copy_header_with_wcs(source_header, wcs):
+    import fitsio
     hdr = fitsio.FITSHDR()
     if source_header is not None:
         for r in source_header.records():

--- a/py/legacypipe/utils.py
+++ b/py/legacypipe/utils.py
@@ -162,6 +162,18 @@ def read_primary_header(fn):
     import fitsio
     return fitsio.read_header(fn)
 
+def copy_header_with_wcs(source_header, wcs):
+    hdr = fitsio.FITSHDR()
+    if source_header is not None:
+        for r in source_header.records():
+            hdr.add_record(r)
+    # Plug the WCS header cards into these images
+    wcs.add_to_header(hdr)
+    hdr.add_record(dict(name='EQUINOX', value=2000., comment='WCS epoch'))
+    hdr.delete('IMAGEW')
+    hdr.delete('IMAGEH')
+    return hdr
+
 def run_ps_thread(parent_pid, parent_ppid, fn, shutdown, event_queue):
     from astrometry.util.run_command import run_command
     from astrometry.util.fits import fits_table, merge_tables


### PR DESCRIPTION
- dropped "brightblob" column

Tractor catalog header currently has:

```
MB_NPRIM=                    1 / Maskbit: non-primary brick area
MB_BRIGH=                    2 / Maskbit: bright star in blob
MB_BAIL =                 1024 / Maskbit: bailed-out processing
MB_MED  =                 2048 / Maskbit: medium-bright star in blob
MB_GAL  =                 4096 / Maskbit: LSLGA large galaxy
MB_CLUST=                 8192 / Maskbit: Cluster
MB_SAT_G=                    4 / Maskbit: saturated (& nearby), g band
MB_SAT_R=                    8 / Maskbit: saturated (& nearby), r band
MB_SAT_Z=                   16 / Maskbit: saturated (& nearby), z band
MB_ALL_G=                   32 / Maskbit: ALLMASK band g
MB_ALL_R=                   64 / Maskbit: ALLMASK band r
MB_ALL_Z=                  128 / Maskbit: ALLMASK band z
MB_WISE1=                  256 / Maskbit: WISE W1 (all masks)
MB_WISE2=                  512 / Maskbit: WISE W2 (all masks)

MBIT_0  = 'NPRIMARY'           / maskbits bit 0 (0x1): not-brick-primary
MBIT_1  = 'BRIGHT  '           / maskbits bit 1 (0x2): bright star nearby
MBIT_2  = 'SATUR_G '           / maskbits bit 2 (0x4): g band saturated
MBIT_3  = 'SATUR_R '           / maskbits bit 3 (0x8): r band saturated
MBIT_4  = 'SATUR_Z '           / maskbits bit 4 (0x10): z band saturated
MBIT_5  = 'ALLMASK_G'          / maskbits bit 5 (0x20): any ALLMASK_G bit set
MBIT_6  = 'ALLMASK_R'          / maskbits bit 6 (0x40): any ALLMASK_R bit set
MBIT_7  = 'ALLMASK_Z'          / maskbits bit 7 (0x80): any ALLMASK_Z bit set
MBIT_8  = 'WISEM1  '           / maskbits bit 8 (0x100): WISE W1 bright star mas
MBIT_9  = 'WISEM2  '           / maskbits bit 9 (0x200): WISE W2 bright star mas
MBIT_10 = 'BAILOUT '           / maskbits bit 10 (0x400): Bailed out of processi
MBIT_11 = 'MEDIUM  '           / maskbits bit 11 (0x800): medium-bright star nea
MBIT_12 = 'GALAXY  '           / maskbits bit 12 (0x1000): LSLGA large galaxy ne
MBIT_13 = 'CLUSTER '           / maskbits bit 13 (0x2000): Globular cluster near

APRAD0  =                  0.5 / (optical) Aperture radius, in arcsec
APRAD1  =                 0.75 / (optical) Aperture radius, in arcsec
APRAD2  =                   1. / (optical) Aperture radius, in arcsec
APRAD3  =                  1.5 / (optical) Aperture radius, in arcsec
APRAD4  =                   2. / (optical) Aperture radius, in arcsec
APRAD5  =                  3.5 / (optical) Aperture radius, in arcsec
APRAD6  =                   5. / (optical) Aperture radius, in arcsec
APRAD7  =                   7. / (optical) Aperture radius, in arcsec

WAPRAD0 =                   3. / (unWISE) Aperture radius, in arcsec
WAPRAD1 =                   5. / (unWISE) Aperture radius, in arcsec
WAPRAD2 =                   7. / (unWISE) Aperture radius, in arcsec
WAPRAD3 =                   9. / (unWISE) Aperture radius, in arcsec
WAPRAD4 =                  11. / (unWISE) Aperture radius, in arcsec

AMASK0  = 'badpix  '           / ALLMASK/ANYMASK bit 2**0=1 meaning
AMASK1  = 'satur   '           / ALLMASK/ANYMASK bit 2**1=2 meaning
AMASK2  = 'interp  '           / ALLMASK/ANYMASK bit 2**2=4 meaning
AMASK4  = 'cr      '           / ALLMASK/ANYMASK bit 2**4=16 meaning
AMASK6  = 'bleed   '           / ALLMASK/ANYMASK bit 2**6=64 meaning
AMASK7  = 'trans   '           / ALLMASK/ANYMASK bit 2**7=128 meaning
AMASK8  = 'edge    '           / ALLMASK/ANYMASK bit 2**8=256 meaning
AMASK9  = 'edge2   '           / ALLMASK/ANYMASK bit 2**9=512 meaning
AMASK11 = 'outlier '           / ALLMASK/ANYMASK bit 2**11=2048 meaning
```