### PR TITLE
Extend frozen SGA galaxy profiles outside their blob & brick

### DIFF
--- a/py/legacypipe/detection.py
+++ b/py/legacypipe/detection.py
@@ -859,14 +859,6 @@ def segment_and_group_sources(image, T, name=None, ps=None, plots=False):
 
     blobslices = keepslices
 
-    # Find sources that do not belong to a blob and add them as
-    # singleton "blobs"; otherwise they don't get optimized.
-    # for sources outside the image bounds, what should we do?
-    inblobs = np.zeros(len(T), bool)
-    for Isrcs in blobsrcs:
-        inblobs[Isrcs] = True
-    del inblobs
-
     # Remap the "blobs" image so that empty regions are = -1 and the blob values
     # correspond to their indices in the "blobsrcs" list.
     if len(blobmap):

--- a/py/legacypipe/farm.py
+++ b/py/legacypipe/farm.py
@@ -684,6 +684,7 @@ def get_blob_iter(skipblobs=None,
     # drop any cached data before we start pickling/multiprocessing
     survey.drop_cache()
 
+    frozen_galaxies = get_frozen_galaxies(T, blobsrcs, blobs, targetwcs, cat)
     refmap = get_blobiter_ref_map(refstars, T_clusters, less_masking, targetwcs)
 
     # Create the iterator over blobs to process
@@ -695,6 +696,7 @@ def get_blob_iter(skipblobs=None,
                           large_galaxies_force_pointsource,
                           less_masking,
                           brick,
+                          frozen_galaxies,
                           max_blobsize=max_blobsize, custom_brick=custom_brick,
                           skipblobs=skipblobs)
     return blobiter

--- a/py/legacypipe/reference.py
+++ b/py/legacypipe/reference.py
@@ -417,10 +417,15 @@ def read_large_galaxies(survey, targetwcs, bands):
     else:
         # Need to initialize islargegalaxy to False because we will bring in
         # pre-burned sources that we do not want to use in MASKBITS.
+        # (we'll set individual .islargegalaxy entries below)
+        # NOTE: fields such as ref_cat, preburned, etc, already exist in the
+        # "galaxies" catalog read from disk.
         galaxies.islargegalaxy = np.zeros(len(galaxies), bool)
         galaxies.radius = np.zeros(len(galaxies), 'f4')
         galaxies.rename('mag_leda', 'mag')
         galaxies.radius = galaxies.diam / 2. / 60. # [degree]
+        from collections import Counter
+        print('Read preburned catalog.  ref_cat entries:', Counter(galaxies.ref_cat).most_common())
 
     galaxies.keep_radius = 2. * galaxies.radius
     galaxies.freezeparams = np.zeros(len(galaxies), bool)

--- a/py/legacypipe/reference.py
+++ b/py/legacypipe/reference.py
@@ -427,8 +427,6 @@ def read_large_galaxies(survey, targetwcs, bands):
         galaxies.islargegalaxy = np.zeros(len(galaxies), bool)
         galaxies.rename('mag_leda', 'mag')
         galaxies.radius = galaxies.diam / 2. / 60. # [degree]
-        from collections import Counter
-        print('Read preburned catalog.  ref_cat entries:', Counter(galaxies.ref_cat).most_common())
 
     galaxies.keep_radius = 2. * galaxies.radius
     galaxies.freezeparams = np.zeros(len(galaxies), bool)

--- a/py/legacypipe/reference.py
+++ b/py/legacypipe/reference.py
@@ -389,7 +389,7 @@ def read_large_galaxies(survey, targetwcs, bands):
     if galfn is None:
         debug('No large-galaxies catalog file')
         return None
-    radius = 1.
+    radius = 2.
     rc,dc = targetwcs.radec_center()
 
     kd = tree_open(galfn, 'largegals')
@@ -403,11 +403,6 @@ def read_large_galaxies(survey, targetwcs, bands):
     del kd
 
     refcat, preburn = get_large_galaxy_version(galfn)
-
-    #print('Large galaxy cat: ', refcat, 'preburn', preburn)
-    #print('ref_cat:', galaxies.ref_cat, 'ref_id:', galaxies.ref_id)
-    #galaxies.about()
-    #print('lslga id:', galaxies.lslga_id)
 
     if not preburn:
         # Original LSLGA
@@ -427,6 +422,7 @@ def read_large_galaxies(survey, targetwcs, bands):
         galaxies.rename('mag_leda', 'mag')
         galaxies.radius = galaxies.diam / 2. / 60. # [degree]
 
+    galaxies.keep_radius = 2. * galaxies.radius
     galaxies.freezeparams = np.zeros(len(galaxies), bool)
     galaxies.sources = np.empty(len(galaxies), object)
     galaxies.sources[:] = None
@@ -434,12 +430,7 @@ def read_large_galaxies(survey, targetwcs, bands):
     # Factor of HyperLEDA to set the galaxy max radius
     radius_max_factor = 2.
 
-    ## use the pre-burned LSLGA catalog
-    #if 'preburned' in galaxies.get_columns():
-    #    preburned = np.logical_and(preburn, galaxies.preburned)
-    #else:
-    #    preburned = np.zeros(len(galaxies), bool)
-
+    # If we're creating tractor Source objects...
     if bands is not None:
         I, = np.nonzero(galaxies.preburned)
         # only fix the parameters of pre-burned galaxies

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1551,7 +1551,7 @@ def _get_both_mods(X):
     timblobmap[Yo,Xo] = blobmap[Yi,Xi]
     del Yo,Xo,Yi,Xi
 
-    srcs_blobs = zip(srcs, srcblobs)
+    srcs_blobs = list(zip(srcs, srcblobs))
 
     if frozen_galaxies is not None:
         from tractor.patch import ModelMask
@@ -1562,6 +1562,7 @@ def _get_both_mods(X):
         for src,bb in frozen_galaxies.items():
             # Does this source (which touches blobs bb) touch any blobs in this tim?
             touchedblobs = timblobs.intersection(bb)
+            #debug(len(touchedblobs), 'blobs in frozen galaxy intersect this tim')
             if len(touchedblobs) == 0:
                 continue
             patch = src.getModelPatch(tim, modelMask=mm)
@@ -1575,7 +1576,9 @@ def _get_both_mods(X):
 
             # Drop this frozen galaxy from the catalog to render, if it is present
             # (ie, if it is in_bounds)
-            srcs_blobs = [(s,b) for s,b in srcs_blobs if s != src]
+            # Can't use "==": they're not the same objects; the "srcs" have been
+            # to oneblob.py and back, and, eg, get their EllipseE types changed.
+            srcs_blobs = [(s,b) for s,b in srcs_blobs if not (s.pos.ra == src.pos.ra and s.pos.dec == src.pos.dec)]
 
     for src,srcblob in srcs_blobs:
         patch = src.getModelPatch(tim)

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1551,6 +1551,8 @@ def _get_both_mods(X):
     timblobmap[Yo,Xo] = blobmap[Yi,Xi]
     del Yo,Xo,Yi,Xi
 
+    srcs_blobs = zip(srcs, srcblobs)
+
     if frozen_galaxies is not None:
         from tractor.patch import ModelMask
         timblobs = set(timblobmap.ravel())
@@ -1571,7 +1573,11 @@ def _get_both_mods(X):
             blobmask = np.isin(timblobmap, touchedblobs)
             blobmod += patch.patch * blobmask
 
-    for src,srcblob in zip(srcs, srcblobs):
+            # Drop this frozen galaxy from the catalog to render, if it is present
+            # (ie, if it is in_bounds)
+            srcs_blobs = [(s,b) for s,b in srcs_blobs if s != src]
+
+    for src,srcblob in srcs_blobs:
         patch = src.getModelPatch(tim)
         if patch is None:
             continue
@@ -1667,6 +1673,7 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
     # Render model images...
     record_event and record_event('stage_coadds: model images')
 
+    debug('Frozen_galaxies:', frozen_galaxies)
     bothmods = mp.map(_get_both_mods, [(tim, cat, T.blob, blobs, targetwcs, frozen_galaxies)
                                        for tim in tims])
     mods = [m for m,b in bothmods]

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1489,9 +1489,10 @@ def _blob_iter(brickname, blobslices, blobsrcs, blobs, targetwcs, tims, cat, ban
 
         yield (brickname, iblob,
                (nblob, iblob, Isrcs, targetwcs, bx0, by0, blobw, blobh,
-               blobmask, subtimargs, [cat[i] for i in Isrcs], bands, plots, ps,
-               reoptimize, iterative, use_ceres, refmap[bslc],
-               large_galaxies_force_pointsource, less_masking))
+                blobmask, subtimargs, [cat[i] for i in Isrcs], bands, plots, ps,
+                reoptimize, iterative, use_ceres, refmap[bslc],
+                large_galaxies_force_pointsource, less_masking,
+                frozen_galaxies.get(iblob, [])))
 
 def _bounce_one_blob(X):
     ''' This just wraps the one_blob function, for debugging &

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1584,13 +1584,19 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
     #cat=None,
     #T=None,
     # --> T.ref_cat, T.ref_id vs refstars
+    # refstars.in_bounds?? no, we want to keep ones in non-unique area too
     print('T')
     T.about()
     print('refstars')
     refstars.about()
-    print('T ref_cat, ref_id:', np.zip(T.ref_cat[T.ref_id > 0], T.ref_id[T.ref_id > 0]))
-    print('refstars ref_cat, ref_id:', np.zip(refstars.ref_cat, refstars.ref_id))
-
+    print('T ref_cat, ref_id:', list(zip(T.ref_cat[T.ref_id > 0], T.ref_id[T.ref_id > 0])))
+    print('refstars ref_cat, ref_id:', list(zip(refstars.ref_cat, refstars.ref_id)))
+    I = (T.ref_id > 0)
+    kept_refs = set(list(zip(T.ref_cat[I], T.ref_id[I])))
+    I = (refstars.freezeparams)
+    orig_refs = set(list(zip(refstars.ref_cat[I], refstars.ref_id[I])))
+    dropped_refs = orig_refs - kept_refs
+    print('Dropped ref sources:', dropped_refs)
 
     bothmods = mp.map(_get_both_mods, [(tim, cat, T.blob, blobs, targetwcs) for tim in tims])
     mods = [m for m,b in bothmods]

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -1176,6 +1176,8 @@ def stage_fitblobs(T=None,
     if len(T.brickname) == 0:
         T.brickname = T.brickname.astype('S8')
     T.objid = np.arange(len(T), dtype=np.int32)
+    if T_donotfit:
+        T_donotfit.objid = np.arange(len(T_donotfit), dtype=np.int32) + len(T)
 
     # How many sources in each blob?
     from collections import Counter
@@ -1195,9 +1197,6 @@ def stage_fitblobs(T=None,
 
     invvars = np.hstack(BB.srcinvvars)
     assert(cat.numberOfParams() == len(invvars))
-
-    if T_donotfit:
-        T_donotfit.objid = np.arange(len(T_donotfit), dtype=np.int32) + len(T)
 
     if write_metrics or get_all_models:
         from legacypipe.format_catalog import format_all_models
@@ -1510,6 +1509,7 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
                  tims=None, ps=None, brickname=None, ccds=None,
                  custom_brick=False,
                  T=None, T_donotfit=None, T_refbail=None,
+                 refstars=None,
                  blobs=None,
                  cat=None, pixscale=None, plots=False,
                  coadd_bw=False, brick=None, W=None, H=None, lanczos=True,
@@ -1577,6 +1577,21 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
 
     # Render model images...
     record_event and record_event('stage_coadds: model images')
+
+    ## reference sources with frozen params that did not get assigned to
+    ## blobs -- add them back in!
+    #refstars=None,
+    #cat=None,
+    #T=None,
+    # --> T.ref_cat, T.ref_id vs refstars
+    print('T')
+    T.about()
+    print('refstars')
+    refstars.about()
+    print('T ref_cat, ref_id:', np.zip(T.ref_cat[T.ref_id > 0], T.ref_id[T.ref_id > 0]))
+    print('refstars ref_cat, ref_id:', np.zip(refstars.ref_cat, refstars.ref_id))
+
+
     bothmods = mp.map(_get_both_mods, [(tim, cat, T.blob, blobs, targetwcs) for tim in tims])
     mods = [m for m,b in bothmods]
     blobmods = [b for m,b in bothmods]


### PR DESCRIPTION
- expand search radius for SGA galaxies to twice their ellipse radii
- find these "frozen galaxies" and add special handling for them:
- remove them from the blob-to-sources mapping, unless they're actually in bounds of the brick
- in oneblob, subtract them from the tims before we start anything else
- when rendering model images: render these frozen galaxies; mask them to all the blobs that their maskbits map would touch (with twice the radius) for the blobmodel images; remove them from the other sources to be fit (for the case where the galaxy is actually inside the brick)
