### PR TITLE
Remove NaN dmags from zpt calculation earlier.

### DIFF
--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -985,9 +985,9 @@ class Measurer(object):
         maglo, maghi = MAGLIM[self.band]
         dmag = dmag[refs.photom &
                     (refs.legacy_survey_mag > maglo) &
-                    (refs.legacy_survey_mag < maghi)]
+                    (refs.legacy_survey_mag < maghi) &
+                    np.isfinite(dmag)]
         if len(dmag):
-            dmag = dmag[np.isfinite(dmag)]
             print('Zeropoint: using', len(dmag), 'good stars')
             dmag, _, _ = sigmaclip(dmag, low=2.5, high=2.5)
             print('Zeropoint: using', len(dmag), 'stars after sigma-clipping')


### PR DESCRIPTION
This hopes to fix the bug @djschlegel reported in [decam-chatter 13012]
where
mosaic/CP/V4.3/CP20151213/k4m_151214_064908_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20160219/k4m_160220_094004_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20170206/k4m_170207_070400_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20170831/k4m_170901_121112_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20171101/k4m_171102_125607_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20170804/k4m_170805_115147_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20170808/k4m_170809_102618_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20170909/k4m_170910_121742_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20180102/k4m_180103_083355_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20170310/k4m_170311_061642_ooi_zd_ls9.fits.fz
mosaic/CP/V4.3/CP20170505/k4m_170506_040128_ooi_zd_ls9.fits.fz
produce NaN zero points.

Attempted fix is to move the NaN cut on dmag outside the len(dmag) check.

I have not verified that this change actually works.