### PR TITLE
[WIP] restore ubercal sky-subtraction option in fit_on_coadds

### DIFF
--- a/py/legacypipe/fit_on_coadds.py
+++ b/py/legacypipe/fit_on_coadds.py
@@ -155,6 +155,10 @@ def ubercal_skysub(tims, targetwcs, survey, brickname, bands, mp,
     from legacypipe.survey import get_rgb, imsave_jpeg
     from astropy.stats import sigma_clipped_stats
 
+    if plots or plots2:
+        import os
+        import matplotlib.pyplot as plt
+
     if plots:
         plt.figure(figsize=(8,6))
         mods = []
@@ -267,9 +271,11 @@ def coadds_skysub(tims, targetwcs, survey, brickname, bands, mp,
     from legacypipe.survey import get_rgb, imsave_jpeg
     from astropy.stats import sigma_clipped_stats
 
-    if plots:
+    if plots or plots2:
         import os
         import matplotlib.pyplot as plt
+        
+    if plots:
         import matplotlib.patches as patches
 
         refs, _ = get_reference_sources(survey, targetwcs, targetwcs.pixel_scale(), ['r'],

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -2726,6 +2726,7 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
               apodize=False,
               splinesky=True,
               subsky=True,
+              ubercal_sky=False,
               constant_invvar=False,
               tycho_stars=True,
               gaia_stars=True,
@@ -2968,6 +2969,7 @@ def run_brick(brick, survey, radec=None, pixscale=0.262,
                   constant_invvar=constant_invvar,
                   splinesky=splinesky,
                   subsky=subsky,
+                  ubercal_sky=ubercal_sky,
                   tycho_stars=tycho_stars,
                   gaia_stars=gaia_stars,
                   large_galaxies=large_galaxies,
@@ -3374,10 +3376,11 @@ python -u legacypipe/runbrick.py --plots --brick 2440p070 --zoom 1900 2400 450 9
     parser.add_argument('--no-galaxy-forcepsf', dest='large_galaxies_force_pointsource',
                         default=True, action='store_false',
                         help='Do not force PSFs within galaxy mask.')
-
     parser.add_argument('--less-masking', default=False, action='store_true',
                         help='Turn off background fitting within MEDIUM mask.')
 
+    parser.add_argument('--ubercal-sky', dest='ubercal_sky', default=False,
+                        action='store_true', help='Use the ubercal sky-subtraction (only used with --fit-on-coadds and --no-subsky).')
     parser.add_argument('--subsky-radii', type=float, nargs=3, default=None,
                         help="""Sky-subtraction radii: rmask, rin, rout [arcsec] (only used with --fit-on-coadds and --no-subsky).
                         Image pixels r<rmask are fully masked and the pedestal sky background is estimated from an annulus


### PR DESCRIPTION
Adds a new keyword, `--ubercal-sky` which is only used with `--fit-on-coadds` and `--no-subsky`. For use with, e.g., M33.