### PR TITLE
drop surveyfn and intermediate un-annotated CCDs table altogether

### DIFF
--- a/py/legacypipe/image.py
+++ b/py/legacypipe/image.py
@@ -1320,7 +1320,7 @@ class LegacySurveyImage(object):
             debug('Freezeparams:', np.sum(refs.islargegalaxy * refs.freezeparams))
             # we only want to subtract pre-burned, frozen galaxies.
             I = np.flatnonzero(refs.islargegalaxy * refs.freezeparams)
-            debug('Found', len(I), 'SGA galaxies to subtract before sky')
+            info('Found', len(I), 'SGA galaxies to subtract before sky')
             if len(I):
                 sub_galaxies = get_galaxy_sources(refs[I], [self.band])
         galmod = None


### PR DESCRIPTION
Previously, we used to write out the table that will become the survey-ccds file, and then annotate it to make the annotated-ccds table.  Later, we dropped that and just write the annotated one, then cut it down to the survey-ccds file.  But the code internally still wrote out the initial file, then re-read it and annotated it before writing out the annotated file.  Drop that.
