### PR TITLE
add the FITBITS column to the sweeps files

### DIFF
--- a/bin/generate-sweep-files.py
+++ b/bin/generate-sweep-files.py
@@ -483,6 +483,7 @@ SWEEP_DTYPE = np.dtype([
     ('PMDEC', '>f4'),
     ('PMDEC_IVAR', '>f4'),
     ('MASKBITS', '>i2'),
+    ('FITBITS', '>i2'),
     ('SERSIC', '>f4'),
     ('SERSIC_IVAR', '>f4')]
 )


### PR DESCRIPTION
This PR adds the `FITBITS` column to the sweeps. It's a rather unassuming PR, but I at least checked that the branch runs to completion to create the sweeps files (with `FITBITS`) from the dr9k tractor catalogs.