### PR TITLE
mark sources that need initial flux estimates

### DIFF
--- a/py/legacypipe/oneblob.py
+++ b/py/legacypipe/oneblob.py
@@ -284,11 +284,15 @@ class OneBlob(object):
             plt.title('Reference-source Masks')
             self.ps.savefig()
 
-        if not self.bigblob:
-            debug('Fitting just fluxes using initial models...')
-            self._fit_fluxes(cat, self.tims, self.bands)
-
         tr = self.tractor(self.tims, cat)
+
+        # Fit any sources marked with 'needs_initial_flux' -- saturated, and SGA
+        fitflux = [src for src in cat if getattr(src, 'needs_initial_flux', False)]
+        if len(fitflux):
+            self._fit_fluxes(cat, self.tims, self.bands, fitcat=fitflux)
+            if self.plots:
+                self._plots(tr, 'Fitting initial fluxes')
+        del fitflux
 
         if self.plots:
             self._plots(tr, 'Initial models')
@@ -643,9 +647,9 @@ class OneBlob(object):
 
             # Definitely keep ref stars (Gaia & Tycho)
             if keepsrc is None and getattr(src, 'reference_star', False):
-                print('Dropped reference star:', src)
+                info('Dropped reference star:', src)
                 src.brightness = src.initial_brightness
-                print('Reset brightness to', src.brightness)
+                info('Reset brightness to', src.brightness)
                 src.force_keep_source = True
                 keepsrc = src
 
@@ -1752,8 +1756,9 @@ class OneBlob(object):
         models.restore_images(self.tims)
         del models
 
-    def _fit_fluxes(self, cat, tims, bands):
-        fitcat = [src for src in cat if not src.freezeparams]
+    def _fit_fluxes(self, cat, tims, bands, fitcat=None):
+        if fitcat is None:
+            fitcat = [src for src in cat if not src.freezeparams]
         if len(fitcat) == 0:
             return
         for src in fitcat:

--- a/py/legacypipe/reference.py
+++ b/py/legacypipe/reference.py
@@ -588,6 +588,7 @@ def get_galaxy_sources(galaxies, bands):
                         NanoMaggies(order=bands, **fluxes),
                         shape)
         assert(np.isfinite(src.getLogPrior()))
+        src.needs_initial_flux = True
         srcs[ii] = src
 
     return srcs

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -789,6 +789,10 @@ def stage_srcs(pixscale=None, targetwcs=None,
     cats = []
     tables = []
     if Tnew is not None:
+        for src,ix,iy in zip(newcat, Tnew.ibx, Tnew.iby):
+            for satmap in saturated_pix:
+                if satmap[iy, ix]:
+                    src.needs_initial_flux = True
         cats.extend(newcat)
         tables.append(Tnew)
     if refstars and len(refstars):


### PR DESCRIPTION
saturated and SGA-preburn sources have poor initial flux estimates.
mark them with a "need_initial_flux" attribute.
fit just the fluxes of those sources at the beginning.
(and drop initial fitting of all fluxes for small blobs)
