### PR TITLE
Update production script and add units to sweeps/external-match files

### DIFF
--- a/bin/dr9-sweeps-and-external.sh
+++ b/bin/dr9-sweeps-and-external.sh
@@ -1,0 +1,125 @@
+#!/bin/bash -l
+#SBATCH -q regular
+#SBATCH -N 1
+#SBATCH -t 04:00:00
+#SBATCH -L SCRATCH,project
+#SBATCH -C haswell
+
+# ADM an all-in-one shell script for running the sweeps and external-match
+# ADM files for DR9. Although you can slurm this, it also usually runs to
+# ADM completion within 4 hours on an interactive node, e.g.
+#   salloc -N 1 -C haswell -t 04:00:00 --qos interactive -L SCRATCH,project
+
+# ADM you may need to change the top-level environment variables from
+# -------------------------------here--------------------------------
+
+# ADM set the data release and hence the main input directory.
+dr=dr9
+drdir=/global/cfs/cdirs/cosmo/work/legacysurvey/$dr
+
+# ADM write to scratch.
+droutdir=$CSCRATCH/$dr
+
+# ADM example set-ups for using custom code are commented out!
+# export LEGACYPIPE_DIR=$HOME/git/legacypipe/
+# source /project/projectdirs/desi/software/desi_environment.sh
+export LEGACYPIPE_DIR=/src/legacypipe
+# export LEGACYPIPE_DIR=$drdir/code/legacypipe
+export PYTHONPATH=/usr/local/lib/python:/usr/local/lib/python3.6/dist-packages:$LEGACYPIPE_DIR/py
+
+# ADM if the bricks and matching files are common to all surveys you will
+# ADM need to uncomment the next line and comment the line in the do block.
+# export BRICKSFILE=$drdir/survey-bricks.fits.gz
+
+# ADM location of external-match files.
+export SDSSDIR=/global/cfs/cdirs/sdss/data/sdss/
+
+# ------------------------------to here------------------------------
+
+# ADM a sensible number of processors on which to run.
+export NUMPROC=$(($SLURM_CPUS_ON_NODE / 2))
+
+# ADM run once for each of the DECaLS and MzLS/BASS surveys.
+for survey in north south
+do
+    # ADM if the bricks and matching files are NOT common to all surveys.
+    export BRICKSFILE=$drdir/$survey/survey-bricks.fits.gz
+
+    # ADM set up the per-survey input and output directories.
+    export INDIR=$drdir/$survey
+    echo working on input directory $INDIR
+    export TRACTOR_INDIR=$INDIR/tractor
+
+    export OUTDIR=$droutdir/$survey
+    echo writing to output directory $OUTDIR
+    export SWEEP_OUTDIR=$OUTDIR/sweep
+    export EXTERNAL_OUTDIR=$OUTDIR/external
+    export TRACTOR_FILELIST=$OUTDIR/tractor_filelist
+
+    mkdir -p $SWEEP_OUTDIR
+    mkdir -p $EXTERNAL_OUTDIR
+
+    # ADM write the bricks of interest to the output directory.
+    find $TRACTOR_INDIR -name 'tractor-*.fits' > $TRACTOR_FILELIST
+    echo wrote list of tractor files to $TRACTOR_FILELIST
+    
+    # ADM run the sweeps. Should never have to use the --ignore option here,
+    # ADM which usually means tthere are some discrepancies in the data model!
+    echo running sweeps for the $survey
+    time srun -N 1 python $LEGACYPIPE_DIR/bin/generate-sweep-files.py \
+         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST --schema blocks \
+         -d $BRICKSFILE $TRACTOR_INDIR $SWEEP_OUTDIR
+    echo done running sweeps for the $survey
+
+    # ADM run each of the external matches.
+    echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits
+    time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
+         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
+         $SDSSDIR/dr7/dr7qso.fit.gz \
+         $TRACTOR_INDIR \
+         $EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits --copycols SMJD PLATE FIBER RERUN
+    echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits
+    
+    echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr12Q.fits
+    time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
+         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
+         $SDSSDIR/dr12/boss/qso/DR12Q/DR12Q.fits \
+         $TRACTOR_INDIR \
+         $EXTERNAL_OUTDIR/survey-$dr-$survey-dr12Q.fits --copycols MJD PLATE FIBERID RERUN_NUMBER
+    echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr12Q.fits
+
+    echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits
+    time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
+         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
+         $SDSSDIR/dr12/boss/qso/DR12Q/Superset_DR12Q.fits \
+         $TRACTOR_INDIR \
+         $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits --copycols MJD PLATE FIBERID
+    echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits
+    
+    echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits
+    time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
+         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
+         $SDSSDIR/dr16/sdss/spectro/redux/specObj-dr16.fits \
+         $TRACTOR_INDIR \
+         $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits --copycols MJD PLATE FIBERID RUN2D
+    echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits
+    
+    echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits
+    time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
+         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
+         $SDSSDIR/dr16/eboss/qso/DR16Q/DR16Q_v4.fits \
+         $TRACTOR_INDIR \
+         $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits --copycols MJD PLATE FIBERID
+    echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits
+    
+    echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr16q-v3.fits
+    time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
+         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
+	 $SDSSDIR/dr16/eboss/qso/DR16Q/DR16Q_Superset_v3.fits \
+         $TRACTOR_INDIR \
+         $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr16q-v3.fits --copycols MJD PLATE FIBERID
+    echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr16q-v3.fits
+done
+
+wait
+echo done writing sweeps and externals for all surveys

--- a/bin/dr9-sweeps-and-external.sh
+++ b/bin/dr9-sweeps-and-external.sh
@@ -62,7 +62,7 @@ do
     # ADM write the bricks of interest to the output directory.
     find $TRACTOR_INDIR -name 'tractor-*.fits' > $TRACTOR_FILELIST
     echo wrote list of tractor files to $TRACTOR_FILELIST
-    
+
     # ADM run the sweeps. Should never have to use the --ignore option here,
     # ADM which usually means tthere are some discrepancies in the data model!
     echo running sweeps for the $survey
@@ -79,7 +79,7 @@ do
          $TRACTOR_INDIR \
          $EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits --copycols SMJD PLATE FIBER RERUN
     echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits
-    
+
     echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr12Q.fits
     time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
          -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
@@ -95,7 +95,7 @@ do
          $TRACTOR_INDIR \
          $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits --copycols MJD PLATE FIBERID
     echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits
-    
+
     echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits
     time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
          -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
@@ -103,7 +103,7 @@ do
          $TRACTOR_INDIR \
          $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits --copycols MJD PLATE FIBERID RUN2D
     echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits
-    
+
     echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits
     time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
          -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \
@@ -111,7 +111,7 @@ do
          $TRACTOR_INDIR \
          $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits --copycols MJD PLATE FIBERID
     echo done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits
-    
+
     echo making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr16q-v3.fits
     time srun -N 1 python $LEGACYPIPE_DIR/bin/match-external-catalog.py \
          -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST \

--- a/bin/generate-sweep-files.py
+++ b/bin/generate-sweep-files.py
@@ -193,7 +193,7 @@ def make_sweep(sweep, bricks, ns):
                 return None, None
             try:
                 objects = fitsio.read(filename, 1, upper=True)
-                chunkheader = fitsio.read_header(filename, 0, upper=True)
+                chunkheader = fitsio.read_header(filename, 0)
             except:
                 if ns.ignore_errors:
                     print('IO error on %s' % filename)

--- a/bin/match-external-catalog.py
+++ b/bin/match-external-catalog.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 import numpy as np
 
 from legacypipe.internal import sharedmem
-from legacypipe.internal.io import iter_tractor, parse_filename, get_units
+from legacypipe.internal.io import iter_tractor, parse_filename, get_units, git_version
 
 import argparse
 import os, sys
@@ -155,6 +155,17 @@ def save_file(filename, data, header, format, unitdict=None):
             # ADM units, so pass an empty string for external columns.
             units = [unitdict[col] if col in unitdict.keys() else ""
                      for col in data.dtype.names]
+
+        # ADM add the external match code version header dependency.
+        dep = [int(key.split("DEPNAM")[-1]) for key in header.keys()
+               if 'DEPNAM' in key]
+        if len(dep) == 0:
+            nextdep = 0
+        else:
+            nextdep = np.max(dep) + 1
+        header["DEPNAM{:02d}".format(nextdep)] = 'match_external'
+        header["DEPVER{:02d}".format(nextdep)] = git_version()
+
         filename = basename + '.fits'
         fitsio.write(filename, data, extname='MATCHED', header=header,
                      clobber=True, units=units)

--- a/bin/match-external-catalog.py
+++ b/bin/match-external-catalog.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 import numpy as np
 
 from legacypipe.internal import sharedmem
-from legacypipe.internal.io import iter_tractor, parse_filename
+from legacypipe.internal.io import iter_tractor, parse_filename, get_units
 
 import argparse
 import os, sys
@@ -25,6 +25,9 @@ def main():
         print("         *** Disable -I for final data product.         ***")
 
     bricks = list_bricks(ns)
+
+    # ADM grab a {FIELD: unit} dict from the first Tractor file.
+    unitdict = get_units(bricks[0][1])
 
     tree, nobj, morecols = read_external(ns.external, ns)
 
@@ -140,13 +143,21 @@ def main():
             del _matched_catalog
 
         for format in ns.format:
-            save_file(ns.dest, matched_catalog, hdr, format)
+            save_file(ns.dest, matched_catalog, hdr, format, unitdict=unitdict)
 
-def save_file(filename, data, header, format):
+def save_file(filename, data, header, format, unitdict=None):
     basename = os.path.splitext(filename)[0]
     if format == 'fits':
+        units = None
+	# ADM derive the units from the data columns if possible.
+        if unitdict is not None:
+            # ADM some columns from external-match files might not have
+            # ADM units, so pass an empty string for external columns.
+            units = [unitdict[col] if col in unitdict.keys() else ""
+                     for col in data.dtype.names]
         filename = basename + '.fits'
-        fitsio.write(filename, data, extname='MATCHED', header=header, clobber=True)
+        fitsio.write(filename, data, extname='MATCHED', header=header,
+                     clobber=True, units=units)
     elif format == 'hdf5':
         filename = basename + '.hdf5'
         import h5py

--- a/py/legacypipe/internal/io.py
+++ b/py/legacypipe/internal/io.py
@@ -1,5 +1,24 @@
 import os, sys
 import re
+import fitsio
+
+def get_units(filename):
+    """Extract a dictionary of {FIELD: unit} from (extension 1 of) a
+    Tractor (or similar FITS) file.
+    """
+    # ADM the header for the first extension.
+    hdr = fitsio.read_header(filename, 1)
+
+    # ADM grab the potential names of each unit for each possible field.
+    tunits = ["TUNIT{}".format(i) for i in range(1, hdr["TFIELDS"]+1)]
+    tfields = [hdr["TTYPE{}".format(i)] for i in range(1, hdr["TFIELDS"]+1)]
+
+    # ADM a dictionary of the unit for each field. The dictionary will
+    # ADM have an empty string for units not included in the Tractor file.
+    unitdict = {tfld.upper(): hdr[tunit] if tunit in hdr.keys() else ""
+                for tfld, tunit in zip(tfields, tunits)}
+
+    return unitdict
 
 def parse_filename(filename):
     """parse filename to check if this is a tractor brick file;

--- a/py/legacypipe/internal/io.py
+++ b/py/legacypipe/internal/io.py
@@ -2,6 +2,26 @@ import os, sys
 import re
 import fitsio
 
+def git_version():
+    """Returns `git describe, or 'unknown' if not a git repo"""
+    # ADM mostly stolen from desitarget.io.gitversion()
+    import os
+    from subprocess import Popen, PIPE, STDOUT
+    origdir = os.getcwd()
+    os.chdir(os.path.dirname(__file__))
+    try:
+        p = Popen(['git', "describe"], stdout=PIPE, stderr=STDOUT)
+    except EnvironmentError:
+        return 'unknown'
+
+    os.chdir(origdir)
+    out = p.communicate()[0]
+    if p.returncode == 0:
+        # - avoid py3 bytes and py3 unicode; get native str in both cases.
+        return str(out.rstrip().decode('ascii'))
+    else:
+        return 'unknown'
+
 def get_units(filename):
     """Extract a dictionary of {FIELD: unit} from (extension 1 of) a
     Tractor (or similar FITS) file.


### PR DESCRIPTION
This PR should address #648 and #649. It adds:

- Units to sweeps and external-match files.
- A git-hash with the version of the code used by `generate-sweep-files.py` or `match-external-catalog.py`.
- A dr9 version of the slurm scrips used to generate sweeps files and match to external catalogs.
    * Rather than updating the existing slurm scrips, I added a new script `dr9-sweeps-and-external.sh`. The old scripts had fallen behind the north/south split and use of docker containers.