### PR TITLE
Include duplicates when constructing the external-match catalogs

### DIFF
--- a/bin/match-external-catalog.py
+++ b/bin/match-external-catalog.py
@@ -58,9 +58,18 @@ def main():
                     return None, None, None
                 else:
                     raise
-        
+
+            # ADM limit to just PRIMARY objects from imaging.
+            ii = objects["BRICK_PRIMARY"]
+            objects = objects[ii]
+
+            # ADM build a tree for the imaging objects.
             pos = radec2pos(objects['RA'], objects['DEC'])
-            d, i = tree.query(pos, 1)
+            imtree = KDTree(pos)
+
+            # ADM match objects in imaging to objects in spectroscopy so
+            # ADM every spectroscopic object finds its nearest match
+            d, i = imtree.query(tree.data, 1)
             assert (objects['OBJID'] != -1).all()
             with pool.critical:
                 mask = d < matched_distance[i]

--- a/bin/match-external-catalog.py
+++ b/bin/match-external-catalog.py
@@ -29,6 +29,9 @@ def main():
     # ADM grab a {FIELD: unit} dict from the first Tractor file.
     unitdict = get_units(bricks[0][1])
 
+    # convert to radian
+    tol = ns.tolerance / (60. * 60.)  * (np.pi / 180)
+
     tree, nobj, morecols, maxdups = read_external(ns.external, tol, ns)
 
     # get the data type of the match
@@ -38,9 +41,6 @@ def main():
     matched_catalog['OBJID'] = -1
 
     matched_distance = sharedmem.empty(nobj, dtype='f4')
-
-    # convert to radian
-    tol = ns.tolerance / (60. * 60.)  * (np.pi / 180)
 
     matched_distance[:] = tol
     nprocessed = np.zeros((), dtype='i8')
@@ -72,9 +72,13 @@ def main():
             _p = np.where(dd < tol)[0]  # ADM the imaging object indices.
             _d = dd[dd < tol]           # ADM the matching distances.
 
+            # ADM bail if there are no matches.
+            if len(_s) == 0:
+                return brickname, 0, len(objects)
+
             # ADM look-up dictionaries of the relevant distances and
             # ADM imaging object indices for each spec object index.
-            ddict, pdict = {i: [] for i in _s}, {i: [] for i in _s}
+            ddict, pdict = {s: [] for s in _s}, {s: [] for s in _s}
             _ = [ddict[s].append(d) for s, d in zip(_s, _d)]
             _ = [pdict[s].append(p) for s, p in zip(_s, _p)]
 

--- a/bin/match-external-catalog.py
+++ b/bin/match-external-catalog.py
@@ -198,11 +198,18 @@ def radec2pos(ra, dec):
     pos[:, 1] *= np.cos(ra / 180. * np.pi)
     return pos
 
-def read_external(filename, ns):
+def read_external(filename, ns=None):
     t0 = time()
     cat = fitsio.FITS(filename, upper=True)[1][:]
 
-    if ns.verbose:
+    # ADM some defaults to make it easier to import this function.
+    _verbose = True
+    _copycols = None
+    if ns is not None:
+        _verbose = ns.verbose
+        _copycols = ns.copycols
+
+    if _verbose:
         print("reading external catalog took %g seconds." % (time() - t0))
         print("%d objects." % len(cat))
 
@@ -215,7 +222,7 @@ def read_external(filename, ns):
         and decname in cat.dtype.names: 
             ra = cat[raname]
             dec = cat[decname]
-            if ns.verbose:
+            if _verbose:
                 print('using %s/%s for positions.' % (raname, decname))
             break
     else:
@@ -227,11 +234,11 @@ def read_external(filename, ns):
 
     tree = KDTree(pos)
 
-    if ns.verbose:
+    if _verbose:
         print("Building KD-Tree took %g seconds." % (time() - t0))
 
     morecols = []
-    if ns.copycols is not None:
+    if _copycols is not None:
         for col in np.atleast_1d(ns.copycols):
             if col not in cat.dtype.names:
                 print('Column {} does not exist in external catalog!'.format(col))


### PR DESCRIPTION
@rongpu noticed that our files of LS sources matched to external spectroscopy miss any duplicates in the external catalogs. This PR modifies `bin/match-external-catalog.py` to include all of the duplicates in the matching process.