### PR TITLE
Split sweeps into three sets of files

### DIFF
--- a/bin/dr9-sweeps-and-external.sh
+++ b/bin/dr9-sweeps-and-external.sh
@@ -38,6 +38,8 @@ export SDSSDIR=/global/cfs/cdirs/sdss/data/sdss/
 
 # ADM a sensible number of processors on which to run.
 export NUMPROC=$(($SLURM_CPUS_ON_NODE / 2))
+# ADM the sweeps need more memory since we started to write three files.
+export SWEEPS_NUMPROC=$(($SLURM_CPUS_ON_NODE / 5))
 
 # ADM run once for each of the DECaLS and MzLS/BASS surveys.
 for survey in north south
@@ -67,7 +69,7 @@ do
     # ADM which usually means tthere are some discrepancies in the data model!
     echo running sweeps for the $survey
     time srun -N 1 python $LEGACYPIPE_DIR/bin/generate-sweep-files.py \
-         -v --numproc $NUMPROC -f fits -F $TRACTOR_FILELIST --schema blocks \
+         -v --numproc $SWEEPS_NUMPROC -f fits -F $TRACTOR_FILELIST --schema blocks \
          -d $BRICKSFILE $TRACTOR_INDIR $SWEEP_OUTDIR
     echo done running sweeps for the $survey
 

--- a/bin/generate-sweep-files.py
+++ b/bin/generate-sweep-files.py
@@ -17,7 +17,7 @@ import fitsio
 # ADM the "light-curves only" directory,
 # ADM and the "remaining Tractor columns not in the sweeps directory".
 # ADM (first is "" as this applies BELOW the level of the /sweep directory.
-outdirnames = ["", "lightcurves", "remainder"]
+outdirnames = ["X.X", "X.X-lightcurves", "X.X-extra"]
 
 def main():
     ns = parse_args()
@@ -89,18 +89,20 @@ def main():
                      format=format)
 
             if len(data) > 0:
-                # ADM write our separate sweeps for:
+                # ADM the columns to always include to form a unique ID.
+                uniqid = [dt for dt in SWEEP_DTYPE.descr if
+                          dt[0]=="RELEASE" or dt[0]=="BRICKID" or dt[0]=="OBJID"]
+                # ADM write out separate sweeps for:
                 # ADM    the SWEEP_DTYPE columns (without light-curves).
                 sweepdt = [dt for dt in SWEEP_DTYPE.descr if 'LC' not in dt[0]]
                 # ADM    the SWEEP_DTYPE columns (just light-curves).
-                lcdt = [dt for dt in SWEEP_DTYPE.descr if 'LC' in dt[0]]
+                lcdt = uniqid + [dt for dt in SWEEP_DTYPE.descr if 'LC' in dt[0]]
                 # ADM    the remaining columns.
-                alldt = [dt for dt in ALL_DTYPE.descr if dt[0] not in SWEEP_DTYPE.names]
-                for dt, preform in zip([sweepdt, lcdt, alldt], outdirnames):
-                    dest = os.path.join(ns.dest, filename)
-                    if len(preform) > 0:
-                        dest = os.path.join(ns.dest, preform,
-                                            "{}-{}".format(preform, filename))
+                alldt = uniqid + [dt for dt in ALL_DTYPE.descr if dt[0] not in SWEEP_DTYPE.names]
+                ender = [".fits", "-lc.fits", "-ex.fits"]
+                for dt, odn, end in zip([sweepdt, lcdt, alldt], outdirnames, ender):
+                    fn = filename.replace(".fits", end)
+                    dest = os.path.join(ns.dest, odn, fn)
                     if len(dt) > 0:
                         newdata = np.empty(len(data), dtype=dt)
                         for col in newdata.dtype.names:
@@ -480,6 +482,12 @@ SWEEP_DTYPE = np.dtype([
     ('LC_NOBS_W2', '>i2', (15,)),
     ('LC_MJD_W1', '>f8', (15,)),
     ('LC_MJD_W2', '>f8', (15,)),
+    ('LC_FRACFLUX_W1', '>f4', (15,)),
+    ('LC_FRACFLUX_W2', '>f4', (15,)),
+    ('LC_RCHISQ_W1', '>f4', (15,)),
+    ('LC_RCHISQ_W2', '>f4', (15,)),
+    ('LC_EPOCH_INDEX_W1', '>i2', (15,)),
+    ('LC_EPOCH_INDEX_W2', '>i2', (15,)),
 #    ('FRACDEV', '>f4'),
 #    ('FRACDEV_IVAR', '>f4'),
     ('SHAPE_R', '>f4'),

--- a/bin/generate-sweep-files.py
+++ b/bin/generate-sweep-files.py
@@ -15,8 +15,8 @@ import fitsio
 
 # ADM these are the directory names for the sweep directory,
 # ADM the "light-curves only" directory,
-# ADM and the "remaining Tractor columns not in the sweeps directory".
-# ADM (first is "" as this applies BELOW the level of the /sweep directory.
+# ADM and the "extra Tractor columns not in the sweeps directory".
+# ADM (these apply BELOW the level of the /sweep directory.
 outdirnames = ["X.X", "X.X-lightcurves", "X.X-extra"]
 
 def main():
@@ -97,7 +97,7 @@ def main():
                 sweepdt = [dt for dt in SWEEP_DTYPE.descr if 'LC' not in dt[0]]
                 # ADM    the SWEEP_DTYPE columns (just light-curves).
                 lcdt = uniqid + [dt for dt in SWEEP_DTYPE.descr if 'LC' in dt[0]]
-                # ADM    the remaining columns.
+                # ADM    the remaining "extra" columns.
                 alldt = uniqid + [dt for dt in ALL_DTYPE.descr if dt[0] not in SWEEP_DTYPE.names]
                 ender = [".fits", "-lc.fits", "-ex.fits"]
                 for dt, odn, end in zip([sweepdt, lcdt, alldt], outdirnames, ender):
@@ -333,7 +333,7 @@ def read_region(brickname, filename, bricksdesc):
 SWEEP_DTYPE = np.dtype([
 # ADM everything IN this list will be written to sweep files
 # ADM with the light-curve columns spun off to their own files.
-# ADM anything NOT in this list will be written to a separate file set.
+# ADM anything NOT in this list will be written to an "extra" file set.
 #   ('BRICK_PRIMARY', '?'),
     ('RELEASE', '>i2'),
     ('BRICKID', '>i4'),


### PR DESCRIPTION
This PR splits the sweeps into 3 separate sets of files:

1. The original sweeps.
2. All of the columns that correspond to light curves.
3. The remaining columns that aren't in (1.) or (2.) but are in the Tractor files.

The data model looks like, for example:

```
1. north/sweep/X.X/sweep-330p030-340p035.fits
2. north/sweep/X.X-lightcurves/sweep-330p030-340p035-lc.fits
3. north/sweep/X.X-extra/sweep-330p030-340p035-ex.fits
```

where the intention would be for `X.X` to be changed to the appropriate data release (`9.1`, etc.).

