### PR TITLE
generalize annular sky-subtraction options

### DIFF
--- a/py/legacypipe/coadds.py
+++ b/py/legacypipe/coadds.py
@@ -950,7 +950,7 @@ def _apphot_one(args):
 
     return result
 
-def get_coadd_headers(hdr, tims, band):
+def get_coadd_headers(hdr, tims, band, coadd_headers={}):
     # Grab these keywords from all input files for this band...
     keys = ['OBSERVAT', 'TELESCOP','OBS-LAT','OBS-LONG','OBS-ELEV',
             'INSTRUME','FILTER']
@@ -998,9 +998,15 @@ def get_coadd_headers(hdr, tims, band):
         name='DATEOBS', value=tt[2],
         comment='Mean DATE-OBS for the stack (UTC)'))
 
+    # add more info from fit_on_coadds
+    if bool(coadd_headers):
+        for key in sorted(coadd_headers.keys()):
+            hdr.add_record(dict(name=key, value=coadd_headers[key][0], comment=coadd_headers[key][1]))
+
 def write_coadd_images(band,
                        survey, brickname, version_header, tims, targetwcs,
                        co_sky,
+                       coadd_headers=None,
                        cowimg=None, cow=None, cowmod=None, cochi2=None,
                        cowblobmod=None,
                        psfdetiv=None, galdetiv=None, congood=None,
@@ -1008,7 +1014,7 @@ def write_coadd_images(band,
 
     hdr = copy_header_with_wcs(version_header, targetwcs)
     # Grab headers from input images...
-    get_coadd_headers(hdr, tims, band)
+    get_coadd_headers(hdr, tims, band, coadd_headers)
     imgs = [
         ('image',  'image', cowimg),
         ('invvar', 'wtmap', cow   ),

--- a/py/legacypipe/fit_on_coadds.py
+++ b/py/legacypipe/fit_on_coadds.py
@@ -158,8 +158,190 @@ def ubercal_skysub(tims, targetwcs, survey, brickname, bands, mp,
         import matplotlib.pyplot as plt
 
     if plots:
+        plt.figure(figsize=(8,6))
+        mods = []
+        for tim in tims:
+            imcopy = tim.getImage().copy()
+            tim.sky.addTo(imcopy, -1)
+            mods.append(imcopy)
+        C = make_coadds(tims, bands, targetwcs, mods=mods, callback=None, mp=mp)
+        imsave_jpeg(os.path.join(survey.output_dir, 'metrics', 'cus', '{}-pipelinesky.jpg'.format(ps.basefn)),
+                    get_rgb(C.comods, bands), origin='lower')
+
+    skydict = {}
+    if subsky_radii is not None:
+        skydict.update({'NSKYANN': (len(subsky_radii) // 2, 'number of sky annuli')})
+        for irad, (rin, rout) in enumerate(zip(subsky_radii[0::2], subsky_radii[1::2])):
+            skydict.update({'SKYRIN{:02d}'.format(irad): (np.float32(rin), 'inner sky radius {} [arcsec]'.format(irad))})
+            skydict.update({'SKYROT{:02d}'.format(irad): (np.float32(rout), 'outer sky radius {} [arcsec]'.format(irad))})
+
+    allbands = np.array([tim.band for tim in tims])
+
+    # we need the full-field mosaics if doing annular sky-subtraction
+    if subsky_radii is not None:
+        allbandtims = []
+    else:
+        allbandtims = None
+
+    for band in sorted(set(allbands)):
+        print('Working on band {}'.format(band))
+        I = np.where(allbands == band)[0]
+
+        bandtims = [tims[ii].imobj.get_tractor_image(
+            gaussPsf=True, pixPsf=False, subsky=False, dq=True, apodize=False)
+            for ii in I]
+
+        # Derive the ubercal correction and then apply it.
+        x = coadds_ubercal(bandtims, coaddtims=[tims[ii] for ii in I],
+                           plots=plots, plots2=plots2, ps=ps, verbose=True)
+        for ii, corr in zip(I, x):
+            skydict.update({'SKCCD{:03d}'.format(ii): (tims[ii].name, 'ubersky CCD {:03d}'.format(ii))})
+            skydict.update({'SKCOR{:03d}'.format(ii): (corr, 'ubersky corr CCD {:03d}'.format(ii))})
+
+        # Apply the correction and return the tims
+        for jj, (correction, ii) in enumerate(zip(x, I)):
+            tims[ii].data += correction
+            tims[ii].sky = ConstantSky(0.0)
+            # Also correct the full-field mosaics
+            bandtims[jj].data += correction
+            bandtims[jj].sky = ConstantSky(0.0)        
+
+        ## Check--
+        #for jj, correction in enumerate(x):
+        #    fulltims[jj].data += correction
+        #newcorrection = coadds_ubercal(fulltims)
+        #print(newcorrection)
+
+        if allbandtims is not None:
+            allbandtims = allbandtims + bandtims
+
+    # Estimate the sky background from an annulus surrounding the object
+    # (assumed to be at the center of the mosaic, targetwcs.crval).
+    if subsky_radii is not None:
+        from astrometry.util.util import Tan
+
+        # the inner and outer radii / annuli are nested in subsky_radii
+        allrin = subsky_radii[0::2]
+        allrout = subsky_radii[1::2]
+        
+        pixscale = targetwcs.pixel_scale()
+        bigH = float(np.ceil(2 * np.max(allrout) / pixscale))
+        bigW = bigH
+
+        # if doing annulur sky-subtraction we need a bigger mosaic
+        bigtargetwcs = Tan(targetwcs.crval[0], targetwcs.crval[1],
+                           bigW/2.+0.5, bigH/2.+0.5,
+                           -pixscale / 3600.0, 0., 0., pixscale / 3600.0,
+                           float(bigW), float(bigH))
+
+        C = make_coadds(allbandtims, bands, bigtargetwcs, callback=None, sbscale=False, mp=mp)
+
+        _, x0, y0 = bigtargetwcs.radec2pixelxy(bigtargetwcs.crval[0], bigtargetwcs.crval[1])
+        xcen, ycen = np.round(x0 - 1).astype('int'), np.round(y0 - 1).astype('int')
+        ymask, xmask = np.ogrid[-ycen:bigH-ycen, -xcen:bigW-xcen]
+
+        refs, _ = get_reference_sources(survey, bigtargetwcs, bigtargetwcs.pixel_scale(), ['r'],
+                                        tycho_stars=True, gaia_stars=True,
+                                        large_galaxies=True, star_clusters=True)
+        refmask = get_reference_map(bigtargetwcs, refs) == 0 # True=skypix
+
+        for coimg, coiv, band in zip(C.coimgs, C.cowimgs, bands):
+            skypix = _build_objmask(coimg, coiv, refmask * (coiv>0))
+
+            for irad, (rin, rout) in enumerate(zip(allrin, allrout)):
+                inmask = (xmask**2 + ymask**2) <= (rin / pixscale)**2
+                outmask = (xmask**2 + ymask**2) <= (rout / pixscale)**2
+                skymask = (outmask*1 - inmask*1) == 1 # True=skypix
+
+                # Find and mask objects, then get the sky.
+                skypix_annulus = np.logical_and(skypix, skymask)
+                #import matplotlib.pyplot as plt ; plt.imshow(skypix_annulus, origin='lower') ; plt.savefig('junk3.png')
+                #import pdb ; pdb.set_trace()
+                
+                if np.sum(skypix_annulus) == 0:
+                    raise ValueError('No pixels in sky!')
+                _skymean, _skymedian, _skysig = sigma_clipped_stats(coimg, mask=np.logical_not(skypix_annulus), sigma=3.0)
+
+                skydict.update({'{}SKYMN{:02d}'.format(band.upper(), irad): (np.float32(_skymean), 'mean {} sky in annulus {}'.format(band, irad))})
+                skydict.update({'{}SKYMD{:02d}'.format(band.upper(), irad): (np.float32(_skymedian), 'median {} sky in annulus {}'.format(band, irad))})
+                skydict.update({'{}SKYSG{:02d}'.format(band.upper(), irad): (np.float32(_skysig), 'sigma {} sky in annulus {}'.format(band, irad))})
+                skydict.update({'{}SKYNP{:02d}'.format(band.upper(), irad): (np.sum(skypix_annulus), 'npix {} sky in annulus {}'.format(band, irad))})
+
+                # the reference annulus is the first one
+                if irad == 0:
+                    skymean, skymedian, skysig = _skymean, _skymedian, _skysig
+                    skypix_mask = skypix_annulus
+                    
+            I = np.where(allbands == band)[0]
+            for ii in I:
+                tims[ii].data -= skymedian
+                #print('Tim', tims[ii], 'after subtracting skymedian: median', np.median(tims[ii].data))
+
+    else:
+        # regular mosaic
+        C = make_coadds(tims, bands, targetwcs, callback=None, sbscale=False, mp=mp)
+
+        refs, _ = get_reference_sources(survey, targetwcs, targetwcs.pixel_scale(), ['r'],
+                                        tycho_stars=True, gaia_stars=True,
+                                        large_galaxies=True, star_clusters=True)
+        refmask = get_reference_map(targetwcs, refs) == 0 # True=skypix
+        
+        for coimg, coiv, band in zip(C.coimgs, C.cowimgs, bands):
+           skypix = refmask * (coiv>0)
+           skypix_mask = _build_objmask(coimg, coiv, skypix)
+           skymean, skymedian, skysig = sigma_clipped_stats(coimg, mask=np.logical_not(skypix_mask), sigma=3.0)
+           
+           skydict.update({'{}SKYMN00'.format(band.upper(), irad): (np.float32(_skymean), 'mean {} sky'.format(band))})
+           skydict.update({'{}SKYMD00'.format(band.upper(), irad): (np.float32(_skymedian), 'median {} sky'.format(band))})
+           skydict.update({'{}SKYSG00'.format(band.upper(), irad): (np.float32(_skysig), 'sigma {} sky'.format(band))})
+           skydict.update({'{}SKYNP00'.format(band.upper(), irad): (np.sum(skypix_mask), 'npix {} sky'.format(band))})
+
+           I = np.where(allbands == band)[0]
+           for ii in I:
+               tims[ii].data -= skymedian
+              # print('Tim', tims[ii], 'after subtracting skymedian: median', np.median(tims[ii].data))
+
+           #print('Band', band, 'Coadd sky:', skymedian)
+           if plots2:
+               plt.clf()
+               plt.hist(coimg.ravel(), bins=50, range=(-3,3), density=True)
+               plt.axvline(skymedian, color='k')
+               for ii in I:
+                   #print('Tim', tims[ii], 'median', np.median(tims[ii].data))
+                   plt.hist((tims[ii].data - skymedian).ravel(), bins=50, range=(-3,3), histtype='step', density=True)
+               plt.title('Band %s: tim pix & skymedian' % band)
+               ps.savefig()
+
+               # Produce skymedian-subtracted, masked image for later RGB plot
+               coimg -= skymedian
+               coimg[~skypix_mask] = 0.
+               #coimg[np.logical_not(skymask * (coiv > 0))] = 0.
+
+    if plots2:
+        plt.clf()
+        plt.imshow(get_rgb(C.coimgs, bands), origin='lower', interpolation='nearest')
+        ps.savefig()
+
+        for band in bands:
+            for tim in tims:
+                if tim.band != band:
+                    continue
+                plt.clf()
+                C = make_coadds([tim], bands, targetwcs, callback=None, sbscale=False, mp=mp)
+                plt.imshow(get_rgb(C.coimgs, bands).sum(axis=2), cmap='gray',
+                           interpolation='nearest', origin='lower')
+                plt.title('Band %s: tim %s' % (band, tim.name))
+                ps.savefig()
+
+    if plots:
         import matplotlib.patches as patches
 
+        # skysub QA
+        C = make_coadds(tims, bands, targetwcs, callback=None, mp=mp)
+        imsave_jpeg(os.path.join(survey.output_dir, 'metrics', 'cus', '{}-customsky.jpg'.format(ps.basefn)),
+                    get_rgb(C.coimgs, bands), origin='lower')
+
+        # ccdpos QA
         refs, _ = get_reference_sources(survey, targetwcs, targetwcs.pixel_scale(), ['r'],
                                         tycho_stars=False, gaia_stars=False,
                                         large_galaxies=True, star_clusters=False)
@@ -202,7 +384,7 @@ def ubercal_skysub(tims, targetwcs, survey, brickname, bands, mp,
             ax.add_patch(patches.Rectangle((cc[0], cc[2]), cc[1]-cc[0], cc[3]-cc[2],
                                            fill=False, lw=2, edgecolor='k'))
 
-            if subsky_radii:
+            if subsky_radii is not None:
                 racen, deccen = targetwcs.crval
                 for rad in subsky_radii:
                     ax.add_patch(patches.Circle((racen, deccen), rad / 3600, fill=False, edgecolor='black', lw=2))
@@ -217,142 +399,6 @@ def ubercal_skysub(tims, targetwcs, survey, brickname, bands, mp,
 
         plt.subplots_adjust(bottom=0.12, wspace=0.05, left=0.12, right=0.97, top=0.95)
         plt.savefig(os.path.join(survey.output_dir, 'metrics', 'cus', '{}-ccdpos.jpg'.format(ps.basefn)))
-
-    if plots:
-        plt.figure(figsize=(8,6))
-        mods = []
-        for tim in tims:
-            imcopy = tim.getImage().copy()
-            tim.sky.addTo(imcopy, -1)
-            mods.append(imcopy)
-        C = make_coadds(tims, bands, targetwcs, mods=mods, callback=None, mp=mp)
-        imsave_jpeg(os.path.join(survey.output_dir, 'metrics', 'cus', '{}-pipelinesky.jpg'.format(ps.basefn)),
-                    get_rgb(C.comods, bands), origin='lower')
-
-    refs, _ = get_reference_sources(survey, targetwcs, targetwcs.pixel_scale(), ['r'],
-                                    tycho_stars=True, gaia_stars=True,
-                                    large_galaxies=True, star_clusters=True)
-    refmask = get_reference_map(targetwcs, refs) == 0 # True=skypix
-    skydict = {}
-    if subsky_radii:
-        skydict.update({'NSKYRAD': (len(subsky_radii), 'number of sky radii')})
-        for irad, rad in enumerate(subsky_radii):
-            skydict.update({'SKYRAD{:02d}'.format(irad): (np.float32(rad), 'sky radius {} [arcsec]'.format(irad))})
-
-    allbands = np.array([tim.band for tim in tims])
-    for band in sorted(set(allbands)):
-        print('Working on band {}'.format(band))
-        I = np.where(allbands == band)[0]
-
-        bandtims = [tims[ii].imobj.get_tractor_image(
-            gaussPsf=True, pixPsf=False, subsky=False, dq=True, apodize=False)
-            for ii in I]
-
-        # Derive the ubercal correction and then apply it.
-        x = coadds_ubercal(bandtims, coaddtims=[tims[ii] for ii in I],
-                           plots=plots, plots2=plots2, ps=ps, verbose=True)
-        #skydict[band] = {'ccds': [tims[ii].name for ii in I], 'delta': x}
-
-        # Apply the correction and return the tims
-        for jj, (correction, ii) in enumerate(zip(x, I)):
-            tims[ii].data += correction
-            tims[ii].sky = ConstantSky(0.0)
-            # Also correct the full-field mosaics
-            bandtims[jj].data += correction
-            bandtims[jj].sky = ConstantSky(0.0)
-
-        ## Check--
-        #for jj, correction in enumerate(x):
-        #    fulltims[jj].data += correction
-        #newcorrection = coadds_ubercal(fulltims)
-        #print(newcorrection)
-
-    H, W, pixscale = targetwcs.get_height(), targetwcs.get_width(), targetwcs.pixel_scale()
-
-    C = make_coadds(tims, bands, targetwcs, callback=None, sbscale=False, mp=mp)
-    for coimg,coiv,band in zip(C.coimgs, C.cowimgs, bands):
-        if subsky_radii:
-            # Estimate the sky background from an annulus surrounding the object
-            # (assumed to be at the center of the mosaic, targetwcs.crval).
-            _, x0, y0 = targetwcs.radec2pixelxy(targetwcs.crval[0], targetwcs.crval[1])
-            xcen, ycen = np.round(x0 - 1).astype('int'), np.round(y0 - 1).astype('int')
-            ymask, xmask = np.ogrid[-ycen:H-ycen, -xcen:W-xcen]
-
-            skypix = _build_objmask(coimg, coiv, refmask * (coiv>0))
-            allrin = subsky_radii[0::2]
-            allrout = subsky_radii[1::2]
-            for irad, (rin, rout) in enumerate(zip(allrin, allrout)):
-            #for irad, (rin, rout) in enumerate(zip(subsky_radii[0:-1], subsky_radii[1:])):
-                inmask = (xmask**2 + ymask**2) <= (rin / pixscale)**2
-                outmask = (xmask**2 + ymask**2) <= (rout / pixscale)**2
-                skymask = (outmask*1 - inmask*1) == 1 # True=skypix
-
-                # Find and mask objects, then get the sky.
-                skypix_annulus = np.logical_and(skypix, skymask)
-                _skymean, _skymedian, _skysig = sigma_clipped_stats(coimg, mask=np.logical_not(skypix_annulus), sigma=3.0)
-
-                skydict.update({'SKYMN{:02d}{}'.format(irad, band): (np.float32(_skymean), 'mean {} sky in annulus {} [nanomaggy]'.format(band, irad))})
-                skydict.update({'SKYMD{:02d}{}'.format(irad, band): (np.float32(_skymedian), 'median {} sky in annulus {} [nanomaggy]'.format(band, irad))})
-                skydict.update({'SKYSG{:02d}{}'.format(irad, band): (np.float32(_skysig), 'sigma {} sky in annulus {} [nanomaggy]'.format(band, irad))})
-                skydict.update({'SKYNP{:02d}{}'.format(irad, band): (np.sum(skypix_annulus), 'npix {} sky in annulus {}'.format(band, irad))})
-                
-                # reference annulus
-                if irad == 0:
-                    skymean, skymedian, skysig = _skymean, _skymedian, _skysig
-                    skypix_mask = skypix_annulus
-
-        else:
-            skypix = refmask * (coiv>0)
-            skypix_mask = _build_objmask(coimg, coiv, skypix)
-            skymean, skymedian, skysig = sigma_clipped_stats(coimg, mask=np.logical_not(skypix_mask), sigma=3.0)
-            
-            skydict.update({'SKYMN00{}'.format(irad, band): (np.float32(_skymean), 'mean {} sky [nanomaggy]'.format(band))})
-            skydict.update({'SKYMD00{}'.format(irad, band): (np.float32(_skymedian), 'median {} sky [nanomaggy]'.format(band))})
-            skydict.update({'SKYSG00{}'.format(irad, band): (np.float32(_skysig), 'sigma {} sky [nanomaggy]'.format(band))})
-            skydict.update({'SKYNP00{}'.format(irad, band): (np.sum(skypix_mask), 'npix {} sky'.format(band))})
-
-        I = np.where(allbands == band)[0]
-        #print('Band', band, 'Coadd sky:', skymedian)
-
-        if plots2:
-            plt.clf()
-            plt.hist(coimg.ravel(), bins=50, range=(-3,3), density=True)
-            plt.axvline(skymedian, color='k')
-            for ii in I:
-                #print('Tim', tims[ii], 'median', np.median(tims[ii].data))
-                plt.hist((tims[ii].data - skymedian).ravel(), bins=50, range=(-3,3), histtype='step', density=True)
-            plt.title('Band %s: tim pix & skymedian' % band)
-            ps.savefig()
-
-            # Produce skymedian-subtracted, masked image for later RGB plot
-            coimg -= skymedian
-            coimg[~skypix_mask] = 0.
-            #coimg[np.logical_not(skymask * (coiv > 0))] = 0.
-
-        for ii in I:
-            tims[ii].data -= skymedian
-            #print('Tim', tims[ii], 'after subtracting skymedian: median', np.median(tims[ii].data))
-
-    if plots2:
-        plt.clf()
-        plt.imshow(get_rgb(C.coimgs, bands), origin='lower', interpolation='nearest')
-        ps.savefig()
-
-        for band in bands:
-            for tim in tims:
-                if tim.band != band:
-                    continue
-                plt.clf()
-                C = make_coadds([tim], bands, targetwcs, callback=None, sbscale=False, mp=mp)
-                plt.imshow(get_rgb(C.coimgs, bands).sum(axis=2), cmap='gray',
-                           interpolation='nearest', origin='lower')
-                plt.title('Band %s: tim %s' % (band, tim.name))
-                ps.savefig()
-
-    if plots:
-        C = make_coadds(tims, bands, targetwcs, callback=None, mp=mp)
-        imsave_jpeg(os.path.join(survey.output_dir, 'metrics', 'cus', '{}-customsky.jpg'.format(ps.basefn)),
-                    get_rgb(C.coimgs, bands), origin='lower')
 
     if plots2:
         plt.clf()
@@ -550,33 +596,7 @@ def stage_fit_on_coadds(
         cotim.imobj.pixscale = pixscale
         cotim.time = tai
         cotim.primhdr = fitsio.FITSHDR()
-        get_coadd_headers(cotim.primhdr, tims, band)
-
-        ## custom sky-subtraction (implies ubercal_sky)
-        #if bool(skydict):
-        #    nccds = len(np.atleast_1d(skydict[band]['ccds']))
-        #    if subsky_radii:
-        #        cotim.primhdr.add_record(dict(name='SKYRAD0', value=np.float32(subsky_radii[0]),
-        #                                      comment='sky masking radius [arcsec]'))
-        #        cotim.primhdr.add_record(dict(name='SKYRAD1', value=np.float32(subsky_radii[1]),
-        #                                      comment='sky inner annulus radius [arcsec]'))
-        #        cotim.primhdr.add_record(dict(name='SKYRAD2', value=np.float32(subsky_radii[2]),
-        #                                      comment='sky outer annulus radius [arcsec]'))
-        #    for ii in np.arange(nccds):
-        #        cotim.primhdr.add_record(dict(name='SKCCD{}'.format(ii), value=skydict[band]['ccds'][ii],
-        #                                      comment='ubersky CCD {} name'.format(ii)))
-        #    for ii in np.arange(nccds):
-        #        cotim.primhdr.add_record(dict(name='SKCOR{}'.format(ii), value=np.float32(skydict[band]['delta'][ii]),
-        #                                      comment='ubersky for CCD {} [nanomaggies]'.format(ii)))
-        #    cotim.primhdr.add_record(dict(name='SKYMEAN{}'.format(band.upper()), value=skydict[band]['mean'],
-        #                                  comment='mean {} sky background [nanomaggies]'.format(band)))
-        #    cotim.primhdr.add_record(dict(name='SKYMED{}'.format(band.upper()), value=skydict[band]['median'],
-        #                                  comment='median {} sky background [nanomaggies]'.format(band)))
-        #    cotim.primhdr.add_record(dict(name='SKYSIG{}'.format(band.upper()), value=skydict[band]['sigma'],
-        #                                  comment='sigma {} sky background [nanomaggies]'.format(band)))
-        #    cotim.primhdr.add_record(dict(name='SKYPIX{}'.format(band.upper()), value=skydict[band]['npix'],
-        #                                  comment='number of pixels in {} sky background'.format(band)))
-
+        get_coadd_headers(cotim.primhdr, tims, band, coadd_headers=skydict)
         cotims.append(cotim)
 
         if plots:

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -673,6 +673,7 @@ def stage_srcs(pixscale=None, targetwcs=None,
                refcat=None, refstars=None,
                T_clusters=None,
                ccds=None,
+               ubercal_sky=False,
                record_event=None,
                large_galaxies=True,
                gaia_stars=True,
@@ -884,7 +885,10 @@ def stage_srcs(pixscale=None, targetwcs=None,
     tlast = tnow
 
     ccds.co_sky = np.zeros(len(ccds), np.float32)
-    sky_overlap = True
+    if ubercal_sky:
+        sky_overlap = False
+    else:
+        sky_overlap = True
     if sky_overlap:
         '''
         A note about units here: we're passing 'sbscale=False' to the
@@ -1793,6 +1797,7 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
                  refmap=None,
                  frozen_galaxies=None,
                  bailout_mask=None,
+                 coadd_headers={},
                  mp=None,
                  record_event=None,
                  **kwargs):
@@ -1903,7 +1908,7 @@ def stage_coadds(survey=None, bands=None, version_header=None, targetwcs=None,
                     apertures=apertures, apxy=apxy,
                     callback=write_coadd_images,
                     callback_args=(survey, brickname, version_header, tims,
-                                   targetwcs, co_sky),
+                                   targetwcs, co_sky, coadd_headers),
                     plots=plots, ps=ps, mp=mp)
     record_event and record_event('stage_coadds: extras')
 
@@ -3586,8 +3591,8 @@ python -u legacypipe/runbrick.py --plots --brick 2440p070 --zoom 1900 2400 450 9
 
     parser.add_argument('--ubercal-sky', dest='ubercal_sky', default=False,
                         action='store_true', help='Use the ubercal sky-subtraction (only used with --fit-on-coadds and --no-subsky).')
-    parser.add_argument('--subsky-radii', type=float, nargs=3, default=None,
-                        help="""Sky-subtraction radii: rmask, rin, rout [arcsec] (only used with --fit-on-coadds and --no-subsky).
+    parser.add_argument('--subsky-radii', type=float, nargs='*', default=None,
+                        help="""Sky-subtraction radii: rin, rout [arcsec] (only used with --fit-on-coadds and --no-subsky).
                         Image pixels r<rmask are fully masked and the pedestal sky background is estimated from an annulus
                         rin<r<rout on each CCD centered on the targetwcs.crval coordinates.""")
     parser.add_argument('--read-serial', dest='read_parallel', default=True,


### PR DESCRIPTION
For low surface-brightness work, where the default spline sky-subtraction can be problematic, allow the `--subsky_radii` optional input to be a vector of annuli.  Only used with `--fit-on-coadds`, `--no-subsky` and `--ubercal-sky`.

Also optionally write out additional header cards by passing a dictionary (`coadd_headers`) with a key / header card and value, comment tuple.

Not quite ready to merge. Need to clean up the documentation a bit.