### PR TITLE
Deep preprocessing

### DIFF
--- a/py/legacypipe/deep-preprocess.py
+++ b/py/legacypipe/deep-preprocess.py
@@ -420,7 +420,7 @@ def stage_deep_preprocess_2(
                 info(len(Igaia), 'stars for halo subtraction')
                 if len(Igaia):
                     halostars = refstars[Igaia]
-            
+
             R = mp.imap_unordered(
                 mask_and_coadd_one,
                 [(i_bim, targetrd, tim_kwargs, im, targetwcs,

--- a/py/legacypipe/deep-preprocess.py
+++ b/py/legacypipe/deep-preprocess.py
@@ -531,7 +531,7 @@ def stage_deep_preprocess_2(
         primhdr.add_record(r)
     primhdr.add_record(dict(name='PRODTYPE', value='ccdinfo',
                             comment='NOAO data product type'))
-    
+
     # Write per-brick CCDs table
     with survey.write_output('ccds-table', brick=brickname) as out:
         ccds.writeto(None, fits_object=out.fits, primheader=primhdr)
@@ -573,7 +573,7 @@ def mask_and_coadd_one(X):
     targetsig = max(deep_sig, tim.psf_sigma + 0.5)
     deep_blursig = np.sqrt(targetsig**2 - deep_sig**2)
     tim_blursig  = np.sqrt(targetsig**2 - tim.psf_sigma**2)
-    
+
     # Blur tim
     assert(tim_blursig > 0)
     blurimg = gaussian_filter(tim.getImage(), tim_blursig)
@@ -794,6 +794,3 @@ if __name__ == '__main__':
     from astrometry.util.ttime import MemMeas
     Time.add_measurement(MemMeas)
     sys.exit(main())
-
-
-# 0436m002

--- a/py/legacypipe/deep-preprocess.py
+++ b/py/legacypipe/deep-preprocess.py
@@ -1,0 +1,631 @@
+import sys
+import os
+import warnings
+
+import numpy as np
+
+import fitsio
+
+from astrometry.util.fits import fits_table, merge_tables
+from astrometry.util.ttime import Time
+
+from legacypipe.runbrick import get_parser, get_runbrick_kwargs, run_brick
+from legacypipe.survey import imsave_jpeg
+from legacypipe.coadds import make_coadds
+from legacypipe.outliers import patch_from_coadd, mask_outlier_pixels, read_outlier_mask_file
+
+import logging
+logger = logging.getLogger('legacypipe.deep-preprocess')
+def info(*args):
+    from legacypipe.utils import log_info
+    log_info(logger, args)
+def debug(*args):
+    from legacypipe.utils import log_debug
+    log_debug(logger, args)
+
+def formatwarning(message, category, filename, lineno, line=None):
+    return 'Warning: %s' % (message)
+warnings.formatwarning = formatwarning
+
+def stage_deep_preprocess(
+        W=3600, H=3600, pixscale=0.262, brickname=None,
+        survey=None,
+        ra=None, dec=None,
+        release=None,
+        plots=False, ps=None,
+        target_extent=None, program_name='runbrick.py',
+        bands=None,
+        do_calibs=True,
+        old_calibs_ok=True,
+        splinesky=True,
+        subsky=True,
+        gaussPsf=False, pixPsf=True, hybridPsf=True,
+        normalizePsf=True,
+        apodize=False,
+        constant_invvar=False,
+        read_image_pixels = True,
+        min_mjd=None, max_mjd=None,
+        gaia_stars=True,
+        mp=None,
+        record_event=None,
+        unwise_dir=None,
+        unwise_tr_dir=None,
+        unwise_modelsky_dir=None,
+        galex_dir=None,
+        command_line=None,
+        read_parallel=True,
+        max_memory_gb=None,
+        refstars=None,
+        **kwargs):
+    from legacypipe.survey import (
+        get_git_version, get_version_header, get_dependency_versions,
+        wcs_for_brick, read_one_tim)
+    from legacypipe.depthcut import make_depth_cut
+
+    from astrometry.util.starutil_numpy import ra2hmsstring, dec2dmsstring
+
+    tlast = Time()
+    record_event and record_event('stage_deep: starting')
+    assert(survey is not None)
+
+    # Get brick object
+    custom_brick = (ra is not None)
+    if custom_brick:
+        from legacypipe.survey import BrickDuck
+        # Custom brick; create a fake 'brick' object
+        brick = BrickDuck(ra, dec, brickname)
+    else:
+        brick = survey.get_brick_by_name(brickname)
+        if brick is None:
+            raise RunbrickError('No such brick: "%s"' % brickname)
+    brickid = brick.brickid
+    brickname = brick.brickname
+
+    # Get WCS object describing brick
+    targetwcs = wcs_for_brick(brick, W=W, H=H, pixscale=pixscale)
+    if target_extent is not None:
+        (x0,x1,y0,y1) = target_extent
+        W = x1-x0
+        H = y1-y0
+        targetwcs = targetwcs.get_subimage(x0, y0, W, H)
+    pixscale = targetwcs.pixel_scale()
+    targetrd = np.array([targetwcs.pixelxy2radec(x,y) for x,y in
+                         [(1,1),(W,1),(W,H),(1,H),(1,1)]])
+    # custom brick -- set RA,Dec bounds
+    if custom_brick:
+        brick.ra1,_  = targetwcs.pixelxy2radec(W, H/2)
+        brick.ra2,_  = targetwcs.pixelxy2radec(1, H/2)
+        _, brick.dec1 = targetwcs.pixelxy2radec(W/2, 1)
+        _, brick.dec2 = targetwcs.pixelxy2radec(W/2, H)
+
+    # Create FITS header with version strings
+    gitver = get_git_version()
+
+    version_header = get_version_header(program_name, survey.survey_dir, release,
+                                        git_version=gitver)
+
+    deps = get_dependency_versions(unwise_dir, unwise_tr_dir, unwise_modelsky_dir, galex_dir)
+    for name,value,comment in deps:
+        version_header.add_record(dict(name=name, value=value, comment=comment))
+    if command_line is not None:
+        version_header.add_record(dict(name='CMDLINE', value=command_line,
+                                       comment='runbrick command-line'))
+    version_header.add_record(dict(name='BRICK', value=brickname,
+                                comment='LegacySurveys brick RRRr[pm]DDd'))
+    version_header.add_record(dict(name='BRICKID' , value=brickid,
+                                comment='LegacySurveys brick id'))
+    version_header.add_record(dict(name='RAMIN'   , value=brick.ra1,
+                                comment='Brick RA min (deg)'))
+    version_header.add_record(dict(name='RAMAX'   , value=brick.ra2,
+                                comment='Brick RA max (deg)'))
+    version_header.add_record(dict(name='DECMIN'  , value=brick.dec1,
+                                comment='Brick Dec min (deg)'))
+    version_header.add_record(dict(name='DECMAX'  , value=brick.dec2,
+                                comment='Brick Dec max (deg)'))
+    # Add NOAO-requested headers
+    version_header.add_record(dict(
+        name='RA', value=ra2hmsstring(brick.ra, separator=':'), comment='Brick center RA (hms)'))
+    version_header.add_record(dict(
+        name='DEC', value=dec2dmsstring(brick.dec, separator=':'), comment='Brick center DEC (dms)'))
+    version_header.add_record(dict(
+        name='CENTRA', value=brick.ra, comment='Brick center RA (deg)'))
+    version_header.add_record(dict(
+        name='CENTDEC', value=brick.dec, comment='Brick center Dec (deg)'))
+    for i,(r,d) in enumerate(targetrd[:4]):
+        version_header.add_record(dict(
+            name='CORN%iRA' %(i+1), value=r, comment='Brick corner RA (deg)'))
+        version_header.add_record(dict(
+            name='CORN%iDEC'%(i+1), value=d, comment='Brick corner Dec (deg)'))
+
+    # Find CCDs
+    ccds = survey.ccds_touching_wcs(targetwcs, ccdrad=None)
+    if ccds is None:
+        raise NothingToDoError('No CCDs touching brick')
+    debug(len(ccds), 'CCDs touching target WCS')
+    survey.drop_cache()
+
+    if 'ccd_cuts' in ccds.get_columns():
+        ccds.cut(ccds.ccd_cuts == 0)
+        debug(len(ccds), 'CCDs survive cuts')
+    else:
+        warnings.warn('Not applying CCD cuts')
+
+    # Cut on bands to be used
+    ccds.cut(np.array([b in bands for b in ccds.filter]))
+    debug('Cut to', len(ccds), 'CCDs in bands', ','.join(bands))
+
+    debug('Cutting on CCDs to be used for fitting...')
+    I = survey.ccds_for_fitting(brick, ccds)
+    if I is not None:
+        debug('Cutting to', len(I), 'of', len(ccds), 'CCDs for fitting.')
+        ccds.cut(I)
+
+    if min_mjd is not None:
+        ccds.cut(ccds.mjd_obs >= min_mjd)
+        debug('Cut to', len(ccds), 'after MJD', min_mjd)
+    if max_mjd is not None:
+        ccds.cut(ccds.mjd_obs <= max_mjd)
+        debug('Cut to', len(ccds), 'before MJD', max_mjd)
+
+    # Create Image objects for each CCD
+    ims = []
+    info('Keeping', len(ccds), 'CCDs:')
+    for ccd in ccds:
+        im = survey.get_image_object(ccd)
+        if survey.cache_dir is not None:
+            im.check_for_cached_files(survey)
+        ims.append(im)
+        info(' ', im, im.band, 'expnum', im.expnum, 'exptime', im.exptime, 'propid', ccd.propid,
+              'seeing %.2f' % (ccd.fwhm*im.pixscale), 'MJD %.3f' % ccd.mjd_obs,
+              'object', getattr(ccd, 'object', '').strip(), '\n   ', im.print_imgpath)
+
+    tnow = Time()
+    debug('Finding images touching brick:', tnow-tlast)
+    tlast = tnow
+
+    if max_memory_gb:
+        # Estimate total memory required for tim pixels
+        mem = sum([im.estimate_memory_required(radecpoly=targetrd,
+                                               mywcs=survey.get_approx_wcs(ccd))
+                                               for im,ccd in zip(ims,ccds)])
+        info('Estimated memory required: %.1f GB' % (mem/1e9))
+        if mem / 1e9 > max_memory_gb:
+            raise RuntimeError('Too much memory required: %.1f > %.1f GB' % (mem/1e9, max_memory_gb))
+
+    keep,_ = make_depth_cut(survey, ccds, bands, targetrd, brick, W, H, pixscale,
+                            plots, ps, splinesky, gaussPsf, pixPsf, normalizePsf,
+                            do_calibs, gitver, targetwcs, old_calibs_ok)
+    Ikeep = np.flatnonzero(keep)
+    deepccds = ccds[Ikeep]
+    deepims = [ims[i] for i in Ikeep]
+    info('Cut to', len(deepccds), 'CCDs required to reach depth targets')
+
+    # Read tims for 'deepccds'
+    args = [(im, targetrd, dict(gaussPsf=gaussPsf, pixPsf=pixPsf,
+                                hybridPsf=hybridPsf, normalizePsf=normalizePsf,
+                                subsky=subsky,
+                                apodize=apodize,
+                                constant_invvar=constant_invvar,
+                                pixels=read_image_pixels,
+                                old_calibs_ok=old_calibs_ok))
+                                for im in deepims]
+    deeptims = list(mp.map(read_one_tim, args))
+    
+    # Start outlier masking...
+    deepC = make_coadds(deeptims, bands, targetwcs, mp=mp, sbscale=False,
+                        allmasks=False, coweights=False)
+    with survey.write_output('outliers-pre', brick=brickname) as out:
+        rgb,kwa = survey.get_rgb(deepC.coimgs, bands)
+        imsave_jpeg(out.fn, rgb, origin='lower', **kwa)
+        del rgb
+
+    # Patch individual-CCD masked pixels from deep coadd
+    patch_from_coadd(deepC.coimgs, targetwcs, bands, deeptims, mp=mp)
+    del deepC
+
+    # Find outliers in deep set...
+    make_badcoadds = True
+    badcoaddspos, badcoaddsneg = mask_outlier_pixels(survey, deeptims, bands, targetwcs, brickname, version_header,
+                                                     mp=mp, plots=plots, ps=ps, make_badcoadds=make_badcoadds,
+                                                     refstars=refstars)
+    deepC = make_coadds(deeptims, bands, targetwcs, mp=mp, sbscale=False,
+                        allmasks=False, coweights=False)
+    with survey.write_output('outliers-post', brick=brickname) as out:
+        rgb,kwa = survey.get_rgb(deepC.coimgs, bands)
+        imsave_jpeg(out.fn, rgb, origin='lower', **kwa)
+        del rgb
+    del deepC
+
+    keys = ['version_header', 'targetrd', 'pixscale', 'targetwcs', 'W','H',
+            'ps', 'brickid', 'brickname', 'brick', 'custom_brick',
+            'target_extent', 'ccds', 'bands', 'survey',
+            'ims', 'deepims', 'deeptims',
+    ]
+    L = locals()
+    rtn = dict([(k,L[k]) for k in keys])
+    return rtn
+
+def stage_deep_preprocess_2(
+        W=3600, H=3600, pixscale=0.262, brickname=None,
+        survey=None,
+        ra=None, dec=None,
+        release=None,
+        plots=False, ps=None,
+        target_extent=None, program_name='runbrick.py',
+        bands=None,
+        do_calibs=True,
+        old_calibs_ok=True,
+        splinesky=True,
+        subsky=True,
+        gaussPsf=False, pixPsf=True, hybridPsf=True,
+        normalizePsf=True,
+        apodize=False,
+        constant_invvar=False,
+        read_image_pixels = True,
+        min_mjd=None, max_mjd=None,
+        gaia_stars=True,
+        mp=None,
+        record_event=None,
+        unwise_dir=None,
+        unwise_tr_dir=None,
+        unwise_modelsky_dir=None,
+        galex_dir=None,
+        command_line=None,
+        read_parallel=True,
+        max_memory_gb=None,
+        refstars=None,
+
+        targetrd=None, targetwcs=None, brick=None, version_header=None,
+        ccds=None,
+        ims=None,
+        deepims=None,
+        deeptims=None,
+
+        **kwargs):
+
+    # Using 'deeptims', create template coadds for outlier detection, AND deep coadds.
+
+    # coadds for patching images...
+    info('Making coadds for patching images...')
+    deepC = make_coadds(deeptims, bands, targetwcs, mp=mp, sbscale=False,
+                        allmasks=False, coweights=False)
+
+    with survey.write_output('outliers_mask', brick=brickname) as out:
+        # empty Primary HDU
+        out.fits.write(None, header=version_header)
+
+        for iband,band in enumerate(bands):
+            btims = [tim for tim in deeptims if tim.band == band]
+            if len(btims) == 0:
+                continue
+            info(len(btims), 'deep images for band', band)
+
+            info('Making blurred reference image...')
+            H,W = targetwcs.shape
+            # Build blurred reference image
+            sigs = np.array([tim.psf_sigma for tim in btims])
+            debug('PSF sigmas:', sigs)
+            targetsig = max(sigs) + 0.5
+            addsigs = np.sqrt(targetsig**2 - sigs**2)
+            debug('Target sigma:', targetsig)
+            debug('Blur sigmas:', addsigs)
+            coimg = np.zeros((H,W), np.float32)
+            cow   = np.zeros((H,W), np.float32)
+            masks = np.zeros((H,W), np.int16)
+
+            results = mp.imap_unordered(
+                blur_resample_one, [(i_btim,tim,sig,targetwcs)
+                                    for i_btim,(tim,sig) in enumerate(zip(btims,addsigs))])
+            for i_btim,r in results:
+                if r is None:
+                    continue
+                Yo,Xo,iacc,wacc,macc = r
+                coimg[Yo,Xo] += iacc
+                cow  [Yo,Xo] += wacc
+                masks[Yo,Xo] |= macc
+                del Yo,Xo,iacc,wacc,macc
+                del r
+            del results
+
+            deep_sig = targetsig
+
+            #
+            veto = np.logical_or(star_veto,
+                                 np.logical_or(
+                binary_dilation(masks & DQ_BITS['bleed'], iterations=3),
+                binary_dilation(masks & DQ_BITS['satur'], iterations=10)))
+            del masks
+
+            bims = [im for im in ims if im.band == band and not im in deepims]
+            info('Running on', len(bims), 'individual images (not in deep set)...')
+            if len(bims) == 0:
+                continue
+
+            patch_img = deepC.coimgs[iband]
+
+            tim_kwargs = dict(gaussPsf=gaussPsf, pixPsf=pixPsf,
+                              hybridPsf=hybridPsf, normalizePsf=normalizePsf,
+                              subsky=subsky,
+                              apodize=apodize,
+                              constant_invvar=constant_invvar,
+                              old_calibs_ok=old_calibs_ok)
+            
+            make_badcoadds=True
+            R = mp.imap_unordered(
+                mask_and_coadd_one, [(i_bim, survey, targetrd, tim_kwargs, im, targetwcs,
+                                      patch_img, coimg, cow, veto, deep_sig, plots,ps)
+                                     for i_bim,im in enumerate(bims)])
+            del coimg, cow, veto
+
+
+            #####
+
+
+            
+            badcoadd_pos = None
+            badcoadd_neg = None
+            if make_badcoadds:
+                badcoadd_pos = np.zeros((H,W), np.float32)
+                badcon_pos   = np.zeros((H,W), np.int16)
+                badcoadd_neg = np.zeros((H,W), np.float32)
+                badcon_neg   = np.zeros((H,W), np.int16)
+
+            for i_btim,r in R:
+                tim = btims[i_btim]
+                if r is None:
+                    # none masked
+                    mask = np.zeros(tim.shape, np.uint8)
+                else:
+                    mask,badco = r
+                    if make_badcoadds:
+                        badhot, badcold = badco
+                        yo,xo,bimg = badhot
+                        badcoadd_pos[yo, xo] += bimg
+                        badcon_pos  [yo, xo] += 1
+                        yo,xo,bimg = badcold
+                        badcoadd_neg[yo, xo] += bimg
+                        badcon_neg  [yo, xo] += 1
+                        del yo,xo,bimg, badhot,badcold
+                    del badco
+                del r
+
+                # Apply the mask!
+                maskbits = get_bits_to_mask()
+                tim.inverr[(mask & maskbits) > 0] = 0.
+                tim.dq[(mask & maskbits) > 0] |= tim.dq_type(DQ_BITS['outlier'])
+
+                # Write output!
+                from legacypipe.utils import copy_header_with_wcs
+                hdr = copy_header_with_wcs(None, tim.subwcs)
+                hdr.add_record(dict(name='IMTYPE', value='outlier_mask',
+                                    comment='LegacySurvey image type'))
+                hdr.add_record(dict(name='CAMERA',  value=tim.imobj.camera))
+                hdr.add_record(dict(name='EXPNUM',  value=tim.imobj.expnum))
+                hdr.add_record(dict(name='CCDNAME', value=tim.imobj.ccdname))
+                hdr.add_record(dict(name='X0', value=tim.x0))
+                hdr.add_record(dict(name='Y0', value=tim.y0))
+
+                # HCOMPRESS;: 943k
+                # GZIP_1: 4.4M
+                # GZIP: 4.4M
+                # RICE: 2.8M
+                extname = '%s-%s-%s' % (tim.imobj.camera, tim.imobj.expnum, tim.imobj.ccdname)
+                out.fits.write(mask, header=hdr, extname=extname, compress='HCOMPRESS')
+            del R
+
+            if make_badcoadds:
+                badcoadd_pos /= np.maximum(badcon_pos, 1)
+                badcoadd_neg /= np.maximum(badcon_neg, 1)
+                badcoadds_pos.append(badcoadd_pos)
+                badcoadds_neg.append(badcoadd_neg)
+
+
+        
+    
+    
+    
+    return None
+
+def mask_and_coadd_one(X):
+    from legacypipe.survey import read_one_tim
+    from scipy.ndimage.filters import gaussian_filter
+    from astrometry.util.resample import resample_with_wcs,OverlapError
+
+    (i_bim, survey, targetrd, tim_kwargs, im, targetwcs, patchimg, coimg, cow, veto,
+     deep_sig, plots, ps) = X
+
+    # - read tim
+    tim = read_one_tim((im, targetrd, tim_kwargs))
+
+    # - patch image
+    patch_from_coadd([patchimg], targetwcs, ['x'], [tim])
+
+    # - compute blurring sigmas for image & reference
+    targetsig = max(deep_sig, tim.psf_sigma + 0.5)
+    deep_blursig = np.sqrt(targetsig**2 - deep_sig**2)
+    tim_blursig  = np.sqrt(targetsig**2 - tim.psf_sigma**2)
+    
+    # - blur & resample for masking coadd
+    blurimg = gaussian_filter(tim.getImage(), tim_blursig)
+    try:
+        Yo,Xo,Yi,Xi,[rimg] = resample_with_wcs(
+            targetwcs, tim.subwcs, [blurimg], intType=np.int16)
+    except OverlapError:
+        return i_bim, None
+    del blurimg
+    blurnorm = 1./(2. * np.sqrt(np.pi) * tim_blursig)
+    wt = tim.getInvvar()[Yi,Xi] / (blurnorm**2)
+    this_sig1 = 1./np.sqrt(np.median(wt[wt>0]))
+
+    #return i_tim, (Yo, Xo, rimg*wt, wt, tim.dq[Yi,Xi])
+
+    refimg = gaussian_filter(coimg, deep_blursig)[Yo,Xo]
+    refblurnorm = 1./(2. * np.sqrt(np.pi) * deep_blursig)
+    refwt = cow[Yo,Xo] / (refblurnorm**2)
+
+    # Compare against reference image...
+    maskedpix = np.zeros(tim.shape, np.uint8)
+
+    # Compute the error on our estimate of (thisimg - co) =
+    # sum in quadrature of the errors on thisimg and co.
+    with np.errstate(divide='ignore'):
+        diffvar = 1./wt + 1./refwt
+        sndiff = (rimg - refimg) / np.sqrt(diffvar)
+    with np.errstate(divide='ignore'):
+        reldiff = ((rimg - refimg) / np.maximum(refimg, this_sig1))
+
+    # Significant pixels
+    hotpix = ((sndiff > 5.) * (reldiff > 2.) *
+              (refwt > 1e-16) * (wt > 0.) *
+              (veto[Yo,Xo] == False))
+    coldpix = ((sndiff < -5.) * (reldiff < -2.) *
+               (refwt > 1e-16) * (wt > 0.) *
+               (veto[Yo,Xo] == False))
+    del reldiff, refwt
+
+    if np.any(hotpix) or np.any(coldpix):
+        hot = np.zeros((H,W), bool)
+        hot[Yo,Xo] = hotpix
+        cold = np.zeros((H,W), bool)
+        cold[Yo,Xo] = coldpix
+        del hotpix, coldpix
+        snmap = np.zeros((H,W), np.float32)
+        snmap[Yo,Xo] = sndiff
+        hot = binary_dilation(hot, iterations=1)
+        cold = binary_dilation(cold, iterations=1)
+        # "warm"
+        hot = np.logical_or(hot,
+                            binary_dilation(hot, iterations=5) * (snmap > 3.))
+        hot = binary_dilation(hot, iterations=1)
+        cold = np.logical_or(cold,
+                             binary_dilation(cold, iterations=5) * (snmap < -3.))
+        cold = binary_dilation(cold, iterations=1)
+        # "lukewarm"
+        hot = np.logical_or(hot,
+                            binary_dilation(hot, iterations=5) * (snmap > 2.))
+        hot = binary_dilation(hot, iterations=3)
+        cold = np.logical_or(cold,
+                             binary_dilation(cold, iterations=5) * (snmap < -2.))
+        cold = binary_dilation(cold, iterations=3)
+        del snmap
+
+        bad, = np.nonzero(hot[Yo,Xo])
+        badhot = (Yo[bad], Xo[bad], tim.getImage()[Yi[bad],Xi[bad]])
+        bad, = np.nonzero(cold[Yo,Xo])
+        badcold = (Yo[bad], Xo[bad], tim.getImage()[Yi[bad],Xi[bad]])
+        badco = badhot,badcold
+
+        # Actually do the masking!
+        # Resample "hot" (in brick coords) back to tim coords.
+        try:
+            mYo,mXo,mYi,mXi,_ = resample_with_wcs(
+                tim.subwcs, targetwcs, intType=np.int16)
+        except OverlapError:
+            pass
+        Ibad, = np.nonzero(hot[mYi,mXi])
+        Ibad2, = np.nonzero(cold[mYi,mXi])
+        info(tim, ': masking', len(Ibad), 'positive outlier pixels and', len(Ibad2), 'negative outlier pixels')
+        maskedpix[mYo[Ibad],  mXo[Ibad]]  = OUTLIER_POS
+        maskedpix[mYo[Ibad2], mXo[Ibad2]] = OUTLIER_NEG
+
+    # - (patch again?)
+    # - resample for regular coadd
+    # - return: outlier mask, Yo,Xo,im,wts for coadd, Yo,Xo,im for badcoadd
+
+
+def main(args=None):
+    import datetime
+    from legacypipe.survey import get_git_version
+
+    print()
+    print('deep-preprocess.py starting at', datetime.datetime.now().isoformat())
+    print('legacypipe git version:', get_git_version())
+    if args is None:
+        print('Command-line args:', sys.argv)
+        cmd = 'python'
+        for vv in sys.argv:
+            cmd += ' {}'.format(vv)
+        print(cmd)
+    else:
+        print('Args:', args)
+    print()
+
+    parser = get_parser()
+
+    parser.set_defaults(stage=['deep_preprocess_2'])
+
+    opt = parser.parse_args(args=args)
+    if opt.brick is None and opt.radec is None:
+        parser.print_help()
+        return -1
+
+    optdict = vars(opt)
+    verbose = optdict.pop('verbose')
+    rgb_stretch = optdict.pop('rgb_stretch', None)
+
+    survey, kwargs = get_runbrick_kwargs(**optdict)
+    if kwargs in [-1, 0]:
+        return kwargs
+    kwargs.update(command_line=' '.join(sys.argv))
+
+    if verbose == 0:
+        lvl = logging.INFO
+    else:
+        lvl = logging.DEBUG
+    logging.basicConfig(level=lvl, format='%(message)s', stream=sys.stdout)
+    # tractor logging is *soooo* chatty
+    logging.getLogger('tractor.engine').setLevel(lvl + 10)
+    # silence "findfont: score(<Font 'DejaVu Sans Mono' ...)" messages
+    logging.getLogger('matplotlib.font_manager').disabled = True
+    # route warnings through the logging system
+    logging.captureWarnings(True)
+    if opt.plots:
+        import matplotlib
+        matplotlib.use('Agg')
+        import pylab as plt
+        plt.figure(figsize=(12,9))
+        plt.subplots_adjust(left=0.07, right=0.99, bottom=0.07, top=0.93,
+                            hspace=0.2, wspace=0.05)
+
+    if rgb_stretch is not None:
+        import legacypipe.survey
+        legacypipe.survey.rgb_stretch_factor = rgb_stretch
+
+    kwargs.update(prereqs_update={ 'deep_preprocess': None,
+                                   'deep_preprocess_2': 'deep_preprocess' })
+    from astrometry.util.stages import CallGlobalTime
+    stagefunc = CallGlobalTime('stage_%s', globals())
+    kwargs.update(stagefunc=stagefunc)
+
+    debug('kwargs:', kwargs)
+
+    rtn = -1
+    try:
+        run_brick(opt.brick, survey, **kwargs)
+        rtn = 0
+    except NothingToDoError as e:
+        print()
+        if hasattr(e, 'message'):
+            print(e.message)
+        else:
+            print(e)
+        print()
+        rtn = 0
+    except RunbrickError as e:
+        print()
+        if hasattr(e, 'message'):
+            print(e.message)
+        else:
+            print(e)
+        print()
+        rtn = -1
+
+    return rtn
+
+if __name__ == '__main__':
+    from astrometry.util.ttime import MemMeas
+    Time.add_measurement(MemMeas)
+    sys.exit(main())
+
+
+# 0436m002

--- a/py/legacypipe/depthcut.py
+++ b/py/legacypipe/depthcut.py
@@ -1,0 +1,336 @@
+import numpy as np
+from legacypipe.utils import find_unique_pixels
+
+def make_depth_cut(survey, ccds, bands, targetrd, brick, W, H, pixscale,
+                   plots, ps, splinesky, gaussPsf, pixPsf, normalizePsf, do_calibs,
+                   gitver, targetwcs, old_calibs_ok, get_depth_maps=False, margin=0.5,
+                   use_approx_wcs=False):
+    if plots:
+        import pylab as plt
+
+    # Add some margin to our DESI depth requirements
+    target_depth_map = dict(g=24.0 + margin, r=23.4 + margin, z=22.5 + margin)
+
+    # List extra (redundant) target percentiles so that increasing the depth at
+    # any of these percentiles causes the image to be kept.
+    target_percentiles = np.array(list(range(2, 10)) +
+                                  list(range(10, 30, 5)) +
+                                  list(range(30, 101, 10)))
+    target_ddepths = np.zeros(len(target_percentiles), np.float32)
+    target_ddepths[target_percentiles < 10] = -0.3
+    target_ddepths[target_percentiles <  5] = -0.6
+    #print('Target percentiles:', target_percentiles)
+    #print('Target ddepths:', target_ddepths)
+
+    cH,cW = H//10, W//10
+    coarsewcs = targetwcs.scale(0.1)
+    coarsewcs.imagew = cW
+    coarsewcs.imageh = cH
+
+    # Unique pixels in this brick (U: cH x cW boolean)
+    U = find_unique_pixels(coarsewcs, cW, cH, None,
+                           brick.ra1, brick.ra2, brick.dec1, brick.dec2)
+    pixscale = 3600. * np.sqrt(np.abs(ccds.cd1_1*ccds.cd2_2 - ccds.cd1_2*ccds.cd2_1))
+    seeing = ccds.fwhm * pixscale
+
+    # Compute the rectangle in *coarsewcs* covered by each CCD
+    slices = []
+    overlapping_ccds = np.zeros(len(ccds), bool)
+    for i,ccd in enumerate(ccds):
+        wcs = survey.get_approx_wcs(ccd)
+        hh,ww = wcs.shape
+        rr,dd = wcs.pixelxy2radec([1,ww,ww,1], [1,1,hh,hh])
+        ok,xx,yy = coarsewcs.radec2pixelxy(rr, dd)
+        y0 = int(np.round(np.clip(yy.min(), 0, cH-1)))
+        y1 = int(np.round(np.clip(yy.max(), 0, cH-1)))
+        x0 = int(np.round(np.clip(xx.min(), 0, cW-1)))
+        x1 = int(np.round(np.clip(xx.max(), 0, cW-1)))
+        if y0 == y1 or x0 == x1:
+            slices.append(None)
+            continue
+        # Check whether this CCD overlaps the unique area of this brick...
+        if not np.any(U[y0:y1+1, x0:x1+1]):
+            info('No overlap with unique area for CCD', ccd.expnum, ccd.ccdname)
+            slices.append(None)
+            continue
+        overlapping_ccds[i] = True
+        slices.append((slice(y0, y1+1), slice(x0, x1+1)))
+
+    keep_ccds = np.zeros(len(ccds), bool)
+    depthmaps = []
+
+    for band in bands:
+        # scalar
+        target_depth = target_depth_map[band]
+        # vector
+        target_depths = target_depth + target_ddepths
+
+        depthiv = np.zeros((cH,cW), np.float32)
+        depthmap = np.zeros_like(depthiv)
+        depthvalue = np.zeros_like(depthiv)
+        last_pcts = np.zeros_like(target_depths)
+        # indices of CCDs we still want to look at in the current band
+        b_inds = np.where(ccds.filter == band)[0]
+        info(len(b_inds), 'CCDs in', band, 'band')
+        if len(b_inds) == 0:
+            continue
+        b_inds = np.array([i for i in b_inds if slices[i] is not None])
+        info(len(b_inds), 'CCDs in', band, 'band overlap target')
+        if len(b_inds) == 0:
+            continue
+        # CCDs that we will try before searching for good ones -- CCDs
+        # from the same exposure number as CCDs we have chosen to
+        # take.
+        try_ccds = set()
+
+        # Try DECaLS data first!
+        Idecals = np.where(ccds.propid[b_inds] == '2014B-0404')[0]
+        if len(Idecals):
+            try_ccds.update(b_inds[Idecals])
+        debug('Added', len(try_ccds), 'DECaLS CCDs to try-list')
+
+        plot_vals = []
+
+        if plots:
+            plt.clf()
+            for i in b_inds:
+                sy,sx = slices[i]
+                x0,x1 = sx.start, sx.stop
+                y0,y1 = sy.start, sy.stop
+                plt.plot([x0,x0,x1,x1,x0], [y0,y1,y1,y0,y0], 'b-', alpha=0.5)
+            plt.title('CCDs overlapping brick: %i in %s band' % (len(b_inds), band))
+            ps.savefig()
+
+            nccds = np.zeros((cH,cW), np.int16)
+            plt.clf()
+            for i in b_inds:
+                nccds[slices[i]] += 1
+            plt.imshow(nccds, interpolation='nearest', origin='lower', vmin=0)
+            plt.colorbar()
+            plt.title('CCDs overlapping brick: %i in %s band (%i / %i / %i)' %
+                      (len(b_inds), band, nccds.min(), np.median(nccds), nccds.max()))
+
+            ps.savefig()
+            #continue
+
+        while len(b_inds):
+            if len(try_ccds) == 0:
+                # Choose the next CCD to look at in this band.
+
+                # A rough point-source depth proxy would be:
+                # metric = np.sqrt(ccds.extime[b_inds]) / seeing[b_inds]
+                # If we want to put more weight on choosing good-seeing images, we could do:
+                #metric = np.sqrt(ccds.exptime[b_inds]) / seeing[b_inds]**2
+
+                # depth would be ~ 1 / (sig1 * seeing); we privilege good seeing here.
+                metric = 1. / (ccds.sig1[b_inds] * seeing[b_inds]**2)
+
+                # This metric is *BIG* for *GOOD* ccds!
+
+                # Here, we try explicitly to include CCDs that cover
+                # pixels that are still shallow by the largest amount
+                # for the largest number of percentiles of interest;
+                # note that pixels with no coverage get depth 0, so
+                # score high in this metric.
+                #
+                # The value is the depth still required to hit the
+                # target, summed over percentiles of interest
+                # (for pixels unique to this brick)
+                depthvalue[:,:] = 0.
+                active = (last_pcts < target_depths)
+                for d in target_depths[active]:
+                    depthvalue += U * np.maximum(0, d - depthmap)
+                ccdvalue = np.zeros(len(b_inds), np.float32)
+                for j,i in enumerate(b_inds):
+                    #ccdvalue[j] = np.sum(depthvalue[slices[i]])
+                    # mean -- we want the most bang for the buck per pixel?
+                    ccdvalue[j] = np.mean(depthvalue[slices[i]])
+                metric *= ccdvalue
+
+                # *ibest* is an index into b_inds
+                ibest = np.argmax(metric)
+                # *iccd* is an index into ccds.
+                iccd = b_inds[ibest]
+                ccd = ccds[iccd]
+                debug('Chose best CCD: seeing', seeing[iccd], 'exptime', ccds.exptime[iccd], 'with value', ccdvalue[ibest])
+
+            else:
+                iccd = try_ccds.pop()
+                ccd = ccds[iccd]
+                debug('Popping CCD from use_ccds list')
+
+            # remove *iccd* from b_inds
+            b_inds = b_inds[b_inds != iccd]
+
+            im = survey.get_image_object(ccd)
+            debug('Band', im.band, 'expnum', im.expnum, 'exptime', im.exptime, 'seeing', im.fwhm*im.pixscale, 'arcsec, propid', im.propid)
+
+            im.check_for_cached_files(survey)
+            debug(im)
+
+            if do_calibs:
+                kwa = dict(git_version=gitver, old_calibs_ok=old_calibs_ok)
+                if gaussPsf:
+                    kwa.update(psfex=False)
+                if splinesky:
+                    kwa.update(splinesky=True)
+                im.run_calibs(**kwa)
+
+            if use_approx_wcs:
+                debug('Using approximate (TAN) WCS')
+                wcs = survey.get_approx_wcs(ccd)
+            else:
+                debug('Reading WCS from', im.imgfn, 'HDU', im.hdu)
+                wcs = im.get_wcs()
+
+            x0,x1,y0,y1,slc = im.get_image_extent(wcs=wcs, radecpoly=targetrd)
+            if x0==x1 or y0==y1:
+                debug('No actual overlap')
+                continue
+            wcs = wcs.get_subimage(int(x0), int(y0), int(x1-x0), int(y1-y0))
+
+            if 'galnorm_mean' in ccds.get_columns():
+                galnorm = ccd.galnorm_mean
+                debug('Using galnorm_mean from CCDs table:', galnorm)
+            else:
+                psf = im.read_psf_model(x0, y0, gaussPsf=gaussPsf, pixPsf=pixPsf,
+                                        normalizePsf=normalizePsf)
+                psf = psf.constantPsfAt((x1-x0)//2, (y1-y0)//2)
+                # create a fake tim to compute galnorm
+                from tractor import PixPos, Flux, ModelMask, Image, NullWCS
+                from legacypipe.survey import SimpleGalaxy
+
+                h,w = 50,50
+                gal = SimpleGalaxy(PixPos(w//2,h//2), Flux(1.))
+                tim = Image(data=np.zeros((h,w), np.float32),
+                            psf=psf, wcs=NullWCS(pixscale=im.pixscale))
+                mm = ModelMask(0, 0, w, h)
+                galmod = gal.getModelPatch(tim, modelMask=mm).patch
+                galmod = np.maximum(0, galmod)
+                galmod /= galmod.sum()
+                galnorm = np.sqrt(np.sum(galmod**2))
+            detiv = 1. / (im.sig1 / galnorm)**2
+            galdepth = -2.5 * (np.log10(5. * im.sig1 / galnorm) - 9.)
+            debug('Galnorm:', galnorm, 'sig1:', im.sig1, 'galdepth', galdepth)
+
+            # Add this image the the depth map...
+            from astrometry.util.resample import resample_with_wcs, OverlapError
+            try:
+                Yo,Xo,_,_,_ = resample_with_wcs(coarsewcs, wcs)
+                debug(len(Yo), 'of', (cW*cH), 'pixels covered by this image')
+            except OverlapError:
+                debug('No overlap')
+                continue
+            depthiv[Yo,Xo] += detiv
+
+            # compute the new depth map & percentiles (including the proposed new CCD)
+            depthmap[:,:] = 0.
+            depthmap[depthiv > 0] = 22.5 - 2.5*np.log10(5./np.sqrt(depthiv[depthiv > 0]))
+            depthpcts = np.percentile(depthmap[U], target_percentiles)
+
+            for i,(p,d,t) in enumerate(zip(target_percentiles, depthpcts, target_depths)):
+                info('  pct % 3i, prev %5.2f -> %5.2f vs target %5.2f %s' % (p, last_pcts[i], d, t, ('ok' if d >= t else '')))
+
+            keep = False
+            # Did we increase the depth of any target percentile that did not already exceed its target depth?
+            if np.any((depthpcts > last_pcts) * (last_pcts < target_depths)):
+                keep = True
+
+            # Add any other CCDs from this same expnum to the try_ccds list.
+            # (before making the plot)
+            I = np.where(ccd.expnum == ccds.expnum[b_inds])[0]
+            try_ccds.update(b_inds[I])
+            debug('Adding', len(I), 'CCDs with the same expnum to try_ccds list')
+
+            if plots:
+                cc = '1' if keep else '0'
+                xx = [Xo.min(), Xo.min(), Xo.max(), Xo.max(), Xo.min()]
+                yy = [Yo.min(), Yo.max(), Yo.max(), Yo.min(), Yo.min()]
+                plot_vals.append(((xx,yy,cc),(last_pcts,depthpcts,keep),im.ccdname))
+
+            if plots and (
+                (len(try_ccds) == 0) or np.all(depthpcts >= target_depths)):
+                plt.clf()
+
+                plt.subplot2grid((2,2),(0,0))
+                plt.imshow(depthvalue, interpolation='nearest', origin='lower',
+                           vmin=0)
+                plt.xticks([]); plt.yticks([])
+                plt.colorbar()
+                plt.title('heuristic value')
+
+                plt.subplot2grid((2,2),(0,1))
+                plt.imshow(depthmap, interpolation='nearest', origin='lower',
+                           vmin=target_depth - 2, vmax=target_depth + 0.5)
+                ax = plt.axis()
+                for (xx,yy,cc) in [p[0] for p in plot_vals]:
+                    plt.plot(xx,yy, '-', color=cc, lw=3)
+                plt.axis(ax)
+                plt.xticks([]); plt.yticks([])
+                plt.colorbar()
+                plt.title('depth map')
+
+                plt.subplot2grid((2,2),(1,0), colspan=2)
+                ax = plt.gca()
+                plt.plot(target_percentiles, target_depths, 'ro', label='Target')
+                plt.plot(target_percentiles, target_depths, 'r-')
+                for (lp,dp,k) in [p[1] for p in plot_vals]:
+                    plt.plot(target_percentiles, lp, 'k-',
+                             label='Previous percentiles')
+                for (lp,dp,k) in [p[1] for p in plot_vals]:
+                    cc = 'b' if k else 'r'
+                    plt.plot(target_percentiles, dp, '-', color=cc,
+                             label='Depth percentiles')
+                ccdnames = ','.join([p[2] for p in plot_vals])
+                plot_vals = []
+
+                plt.ylim(target_depth - 2, target_depth + 0.5)
+                plt.xscale('log')
+                plt.xlabel('Percentile')
+                plt.ylabel('Depth')
+                plt.title('depth percentiles')
+                plt.suptitle('%s %i-%s, exptime %.0f, seeing %.2f, band %s' %
+                             (im.camera, im.expnum, ccdnames, im.exptime,
+                              im.pixscale * im.fwhm, band))
+                ps.savefig()
+
+            if keep:
+                info('Keeping this exposure')
+            else:
+                info('Not keeping this exposure')
+                depthiv[Yo,Xo] -= detiv
+                continue
+
+            keep_ccds[iccd] = True
+            last_pcts = depthpcts
+
+            if np.all(depthpcts >= target_depths):
+                info('Reached all target depth percentiles for band', band)
+                break
+
+        if get_depth_maps:
+            if np.any(depthiv > 0):
+                depthmap[:,:] = 0.
+                depthmap[depthiv > 0] = 22.5 -2.5*np.log10(5./np.sqrt(depthiv[depthiv > 0]))
+                depthmap[np.logical_not(U)] = np.nan
+                depthmaps.append((band, depthmap.copy()))
+
+        if plots:
+            I = np.where(ccds.filter == band)[0]
+            plt.clf()
+            plt.plot(seeing[I], ccds.exptime[I], 'k.')
+            # which CCDs from this band are we keeping?
+            kept, = np.nonzero(keep_ccds)
+            if len(kept):
+                kept = kept[ccds.filter[kept] == band]
+                plt.plot(seeing[kept], ccds.exptime[kept], 'ro')
+            plt.xlabel('Seeing (arcsec)')
+            plt.ylabel('Exptime (sec)')
+            plt.title('CCDs kept for band %s' % band)
+            plt.ylim(0, np.max(ccds.exptime[I]) * 1.1)
+            ps.savefig()
+
+    if get_depth_maps:
+        return (keep_ccds, overlapping_ccds, depthmaps)
+    return keep_ccds, overlapping_ccds
+

--- a/py/legacypipe/depthcut.py
+++ b/py/legacypipe/depthcut.py
@@ -55,7 +55,7 @@ def make_depth_cut(survey, ccds, bands, targetrd, brick, W, H, pixscale,
         wcs = survey.get_approx_wcs(ccd)
         hh,ww = wcs.shape
         rr,dd = wcs.pixelxy2radec([1,ww,ww,1], [1,1,hh,hh])
-        ok,xx,yy = coarsewcs.radec2pixelxy(rr, dd)
+        _,xx,yy = coarsewcs.radec2pixelxy(rr, dd)
         y0 = int(np.round(np.clip(yy.min(), 0, cH-1)))
         y1 = int(np.round(np.clip(yy.max(), 0, cH-1)))
         x0 = int(np.round(np.clip(xx.min(), 0, cW-1)))
@@ -203,7 +203,7 @@ def make_depth_cut(survey, ccds, bands, targetrd, brick, W, H, pixscale,
                 debug('Reading WCS from', im.imgfn, 'HDU', im.hdu)
                 wcs = im.get_wcs()
 
-            x0,x1,y0,y1,slc = im.get_image_extent(wcs=wcs, radecpoly=targetrd)
+            x0,x1,y0,y1,_ = im.get_image_extent(wcs=wcs, radecpoly=targetrd)
             if x0==x1 or y0==y1:
                 debug('No actual overlap')
                 continue

--- a/py/legacypipe/depthcut.py
+++ b/py/legacypipe/depthcut.py
@@ -374,4 +374,3 @@ def make_depth_cut(survey, ccds, bands, targetrd, brick, W, H, pixscale,
     if get_depth_maps:
         return (keep_ccds, overlapping_ccds, depthmaps)
     return keep_ccds, overlapping_ccds
-

--- a/py/legacypipe/forced_photom.py
+++ b/py/legacypipe/forced_photom.py
@@ -534,7 +534,7 @@ def forced_photom_one_ccd(survey, catsurvey_north, catsurvey_south, resolve_dec,
         halostars = gaia[Igaia]
         print('Got', len(gaia), 'Gaia stars,', len(halostars), 'for halo subtraction')
         moffat = True
-        halos = subtract_one((tim, halostars, moffat, old_calibs_ok))
+        halos = subtract_one((0, tim, halostars, moffat, old_calibs_ok))
         tim.data -= halos
 
     # The "north" and "south" directories often don't have

--- a/py/legacypipe/forced_photom.py
+++ b/py/legacypipe/forced_photom.py
@@ -534,7 +534,7 @@ def forced_photom_one_ccd(survey, catsurvey_north, catsurvey_south, resolve_dec,
         halostars = gaia[Igaia]
         print('Got', len(gaia), 'Gaia stars,', len(halostars), 'for halo subtraction')
         moffat = True
-        halos = subtract_one((0, tim, halostars, moffat, old_calibs_ok))
+        _,halos = subtract_one((0, tim, halostars, moffat, old_calibs_ok))
         tim.data -= halos
 
     # The "north" and "south" directories often don't have

--- a/py/legacypipe/halos.py
+++ b/py/legacypipe/halos.py
@@ -11,23 +11,24 @@ def debug(*args):
 
 def subtract_halos(tims, refs, bands, mp, plots, ps, moffat=True,
                    old_calibs_ok=False):
-    args = [(tim, refs, moffat, old_calibs_ok) for tim in tims]
-    haloimgs = mp.map(subtract_one, args)
-    for tim,h in zip(tims, haloimgs):
-        tim.data -= h
+    args = [(itim, tim, refs, moffat, old_calibs_ok) for itim,tim in enumerate(tims)]
+    haloimgs = mp.imap_unordered(subtract_one, args)
+    for itim,h in haloimgs:
+        if h != 0.:
+            tims[itim].data -= h
 
 def subtract_one(X):
-    tim, refs, moffat, old_calibs_ok = X
+    itim, tim, refs, moffat, old_calibs_ok = X
     if tim.imobj.camera != 'decam':
         print('Warning: Stellar halo subtraction is only implemented for DECam')
-        return 0.
+        return itim, 0.
     col = 'decam_mag_%s' % tim.band
     if not col in refs.get_columns():
         print('Warning: no support for halo subtraction in band %s' % tim.band)
-        return 0.
-    return decam_halo_model(refs, tim.time.toMjd(), tim.subwcs,
-                            tim.imobj.pixscale, tim.band, tim.imobj, moffat,
-                            old_calibs_ok=old_calibs_ok)
+        return itim, 0.
+    return itim, decam_halo_model(refs, tim.time.toMjd(), tim.subwcs,
+                                  tim.imobj.pixscale, tim.band, tim.imobj, moffat,
+                                  old_calibs_ok=old_calibs_ok)
 
 def moffat(rr, alpha, beta):
     return (beta-1.)/(np.pi * alpha**2)*(1. + (rr/alpha)**2)**(-beta)

--- a/py/legacypipe/halos.py
+++ b/py/legacypipe/halos.py
@@ -14,8 +14,7 @@ def subtract_halos(tims, refs, bands, mp, plots, ps, moffat=True,
     args = [(itim, tim, refs, moffat, old_calibs_ok) for itim,tim in enumerate(tims)]
     haloimgs = mp.imap_unordered(subtract_one, args)
     for itim,h in haloimgs:
-        if h != 0.:
-            tims[itim].data -= h
+        tims[itim].data -= h
 
 def subtract_one(X):
     itim, tim, refs, moffat, old_calibs_ok = X

--- a/py/legacypipe/outliers.py
+++ b/py/legacypipe/outliers.py
@@ -262,6 +262,7 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
             if make_badcoadds:
                 badcoadd_pos /= np.maximum(badcon_pos, 1)
                 badcoadd_neg /= np.maximum(badcon_neg, 1)
+                del badcon_pos, badcon_neg
                 badcoadds_pos.append(badcoadd_pos)
                 badcoadds_neg.append(badcoadd_neg)
 

--- a/py/legacypipe/outliers.py
+++ b/py/legacypipe/outliers.py
@@ -176,8 +176,10 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
             cow   = np.zeros((H,W), np.float32)
             masks = np.zeros((H,W), np.int16)
 
-            R = mp.map(blur_resample_one, [(tim,sig,targetwcs) for tim,sig in zip(btims,addsigs)])
-            for tim,r in zip(btims, R):
+            results = mp.imap_unordered(
+                blur_resample_one, [(i_btim,tim,sig,targetwcs)
+                                    for i_btim,(tim,sig) in enumerate(zip(btims,addsigs))])
+            for i_btim,r in results:
                 if r is None:
                     continue
                 Yo,Xo,iacc,wacc,macc = r
@@ -185,7 +187,8 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
                 cow  [Yo,Xo] += wacc
                 masks[Yo,Xo] |= macc
                 del Yo,Xo,iacc,wacc,macc
-            del r,R
+                del r
+            del results
 
             #
             veto = np.logical_or(star_veto,
@@ -200,8 +203,9 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
             #     plt.title('SATUR, BLEED veto (%s band)' % band)
             #     ps.savefig()
 
-            R = mp.map(compare_one, [(tim, sig, targetwcs, coimg,cow, veto, make_badcoadds, plots,ps)
-                                     for tim,sig in zip(btims,addsigs)])
+            R = mp.imap_unordered(
+                compare_one, [(i_btim, tim, sig, targetwcs, coimg, cow, veto, make_badcoadds, plots,ps)
+                              for i_btim,(tim,sig) in enumerate(zip(btims,addsigs))])
             del coimg, cow, veto
 
             badcoadd_pos = None
@@ -212,7 +216,8 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
                 badcoadd_neg = np.zeros((H,W), np.float32)
                 badcon_neg   = np.zeros((H,W), np.int16)
 
-            for r,tim in zip(R, btims):
+            for i_btim,r in R:
+                tim = btims[i_btim]
                 if r is None:
                     # none masked
                     mask = np.zeros(tim.shape, np.uint8)
@@ -228,6 +233,7 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
                         badcon_neg  [yo, xo] += 1
                         del yo,xo,bimg, badhot,badcold
                     del badco
+                del r
 
                 # Apply the mask!
                 maskbits = get_bits_to_mask()
@@ -251,8 +257,7 @@ def mask_outlier_pixels(survey, tims, bands, targetwcs, brickname, version_heade
                 # RICE: 2.8M
                 extname = '%s-%s-%s' % (tim.imobj.camera, tim.imobj.expnum, tim.imobj.ccdname)
                 out.fits.write(mask, header=hdr, extname=extname, compress='HCOMPRESS')
-
-            del r,R
+            del R
 
             if make_badcoadds:
                 badcoadd_pos /= np.maximum(badcon_pos, 1)
@@ -267,7 +272,7 @@ def compare_one(X):
     from scipy.ndimage.morphology import binary_dilation
     from astrometry.util.resample import resample_with_wcs,OverlapError
 
-    (tim,sig,targetwcs, coimg,cow, veto, make_badcoadds, plots,ps) = X
+    (i_tim,tim,sig,targetwcs, coimg,cow, veto, make_badcoadds, plots,ps) = X
 
     if plots:
         import pylab as plt
@@ -279,7 +284,7 @@ def compare_one(X):
         Yo,Xo,Yi,Xi,[rimg] = resample_with_wcs(
             targetwcs, tim.subwcs, [img], intType=np.int16)
     except OverlapError:
-        return None
+        return i_tim,None
     del img
     blurnorm = 1./(2. * np.sqrt(np.pi) * sig)
     wt = tim.getInvvar()[Yi,Xi] / np.float32(blurnorm**2)
@@ -361,7 +366,7 @@ def compare_one(X):
     del reldiff, otherwt
 
     if (not np.any(hotpix)) and (not np.any(coldpix)):
-        return None
+        return i_tim,None
 
     hot = np.zeros((H,W), bool)
     hot[Yo,Xo] = hotpix
@@ -422,32 +427,32 @@ def compare_one(X):
         mYo,mXo,mYi,mXi,_ = resample_with_wcs(
             tim.subwcs, targetwcs, intType=np.int16)
     except OverlapError:
-        return None
+        return i_tim,None
     Ibad, = np.nonzero(hot[mYi,mXi])
     Ibad2, = np.nonzero(cold[mYi,mXi])
     info(tim, ': masking', len(Ibad), 'positive outlier pixels and', len(Ibad2), 'negative outlier pixels')
     maskedpix[mYo[Ibad],  mXo[Ibad]]  = OUTLIER_POS
     maskedpix[mYo[Ibad2], mXo[Ibad2]] = OUTLIER_NEG
 
-    return maskedpix,badco
+    return i_tim, (maskedpix,badco)
 
 
 def blur_resample_one(X):
     from scipy.ndimage.filters import gaussian_filter
     from astrometry.util.resample import resample_with_wcs,OverlapError
 
-    tim,sig,targetwcs = X
+    i_tim,tim,sig,targetwcs = X
 
     img = gaussian_filter(tim.getImage(), sig)
     try:
         Yo,Xo,Yi,Xi,[rimg] = resample_with_wcs(
             targetwcs, tim.subwcs, [img], intType=np.int16)
     except OverlapError:
-        return None
+        return i_tim, None
     del img
     blurnorm = 1./(2. * np.sqrt(np.pi) * sig)
     wt = tim.getInvvar()[Yi,Xi] / (blurnorm**2)
-    return (Yo, Xo, rimg*wt, wt, tim.dq[Yi,Xi])
+    return i_tim, (Yo, Xo, rimg*wt, wt, tim.dq[Yi,Xi])
 
 def patch_from_coadd(coimgs, targetwcs, bands, tims, mp=None):
     H,W = targetwcs.shape

--- a/py/legacypipe/runbrick.py
+++ b/py/legacypipe/runbrick.py
@@ -611,13 +611,11 @@ def stage_halos(pixscale=None, targetwcs=None,
 
     # Subtract star halos?
     if star_halos and refstars:
-        Igaia = []
-        gaia = refstars
         Igaia, = np.nonzero(refstars.isgaia * refstars.pointsource)
         debug(len(Igaia), 'stars for halo subtraction')
         if len(Igaia):
             from legacypipe.halos import subtract_halos
-            halostars = gaia[Igaia]
+            halostars = refstars[Igaia]
 
             if plots:
                 from legacypipe.runbrick_plots import halo_plots_before, halo_plots_after


### PR DESCRIPTION
In bricks with many exposures, run preprocessing on individual CCDs at a time, avoiding huge memory use.  This produces:
- image coadds & invvars
- detection maps
- outliers masks

The outlier masks are somewhat different than the main pipeline.  The images and invvars are very similar.
