### PR TITLE
Re-adding mpi4py to legacypipe docker image and building MPICH from scratch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,8 +44,29 @@ RUN apt -y update && apt install -y apt-utils \
     python3-pip \
     source-extractor \
     psfex \
+    build-essential \ 
+    gfortran \
+    libcurl4 \
+    wget \
     # Remove APT files
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Build MPICH for NERSC/Perlmutter
+ARG mpich=4.0.2
+ARG mpich_prefix=mpich-$mpich
+
+RUN \
+    wget https://www.mpich.org/static/downloads/$mpich/$mpich_prefix.tar.gz \
+    && tar xvzf $mpich_prefix.tar.gz                                        \
+    && cd $mpich_prefix                                                     \
+    && FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch ./configure \
+    && make -j 16                                                           \
+    && make install                                                         \
+    && make clean                                                           \
+    && cd ..                                                                \
+    && rm -rf $mpich_prefix
+
+RUN /sbin/ldconfig
 
 # Pip installs
 RUN for x in \
@@ -61,6 +82,7 @@ RUN for x in \
     astropy \
     photutils \
     zmq \
+    mpi4py \
     ; do pip3 install $x; done \
     && rm -Rf /root/.cache/pip
 


### PR DESCRIPTION
The docker image for the `legacypipe` container recently removed `mpi4py`.  This caused some downstream effects in `legacyhalos` which builds off of the `legacypipe` base image.  This PR installs `mpi4py` into the `legacyhalos` dockerfile.

Before merging, we need to verify that this also works on Mac M1/M2 chips.  Leaving this as a draft PR until then.

Remarks:
* Getting `mpi4py` to work on Perlmutter at NERSC is [not](https://docs.nersc.gov/development/shifter/how-to-use/#using-mpi-in-shifter) [straight forward](https://docs.nersc.gov/development/languages/python/parallel-python/#mpi4py-in-your-custom-conda-environment).  This approach follows the recommended NERSC instructions for building MPICH and then installing `mpi4py` (see [here](https://gitlab.com/NERSC/nersc-official-images/-/blob/main/nersc/mpi4py/3.1.4-cpu/Containerfile?ref_type=heads))
* Building MPICH takes ~30 minutes to run, so this change adds exceptional overhead to the docker build.
* Other approaches, such as installing `libmpich` with apt-get then pointing pip to the binary when installing mpi4py sadly did not work. 
* Tested that this fixes the legacyhalos issue

