### PR TITLE
Updates to python code and shell script to run sweeps and external-match files for DR11

### DIFF
--- a/bin/dr11-sweeps-and-external.sh
+++ b/bin/dr11-sweeps-and-external.sh
@@ -31,15 +31,14 @@ mopup=true
 # ADM set the data release and hence the main input directory.
 dr=dr11
 drdir=/global/cfs/cdirs/cosmo/work/legacysurvey/$dr
-drdir=/pscratch/sd/a/adamyers/legacysurvey/$dr
 
 # ADM write to scratch.
 droutdir=$SCRATCH/$dr
 
 # ADM uncomment these to pull and enter the docker container.
-# ADM this is useful if NOT parallelizing across multiple nodes using srun.
-# shifterimg pull docker:legacysurvey/legacypipe:DR10.0.1
-# shifter --image docker:legacysurvey/legacypipe:DR10.0.1 bash
+# ADM this is useful if NOT parallelizing across nodes using srun.
+# shifterimg pull docker:legacysurvey/legacypipe:DR11.0.1
+# shifter --image docker:legacysurvey/legacypipe:DR11.0.1 bash
 
 # ADM example set-ups for using custom code are commented out!
 # ADM the UN-commented code is for the docker container.
@@ -47,11 +46,11 @@ export LEGACYPIPE_DIR=/src/legacypipe
 
 # ADM an abstruse way of getting my home directory as $HOME
 # ADM can be redefined in docker containers.
-HOM=`eval echo "~$USER"`
+#HOM=`eval echo "~$USER"`
 # ADM the next line can be uncommented for, e.g., developing code.
-export LEGACYPIPE_DIR=$HOM/git/legacypipe/
+#export LEGACYPIPE_DIR=$HOM/git/legacypipe/
 
-export PYTHONPATH=/usr/local/lib/python:$LEGACYPIPE_DIR/py
+#export PYTHONPATH=/usr/local/lib/python:$LEGACYPIPE_DIR/py
 
 # ADM location of external-match files.
 export SDSSDIR=/global/cfs/cdirs/sdss/data/sdss/
@@ -61,14 +60,15 @@ export SDSSDIR=/global/cfs/cdirs/sdss/data/sdss/
 # ADM a sensible number of processors on which to run.
 export NUMPROC=$((SLURM_CPUS_ON_NODE / 2))
 # ADM the sweeps need more memory since we started to write three files.
-# ADM $SLURM_CPUS_ON_NODE / 6 works well for dr10.
+# ADM $SLURM_CPUS_ON_NODE / 6 works well for dr11, and takes ~2 hours.
+# ADM although some mopping up with $SLURM_CPUS_ON_NODE / 30 is needed.
 export SWEEPS_NUMPROC=$((SLURM_CPUS_ON_NODE / 6))
 
 # ADM if the bricks and matching files are common to all surveys then
 # ADM uncomment the next line and comment the subsequent for line.
 #for survey in ""
 # ADM run once for each of the DECaLS and MzLS/BASS surveys.
-for survey in south
+for survey in south north
 do
 
     # ADM the file that holds general information about LS bricks.

--- a/bin/dr11-sweeps-and-external.sh
+++ b/bin/dr11-sweeps-and-external.sh
@@ -1,0 +1,166 @@
+#!/bin/bash -l
+#SBATCH -q regular
+#SBATCH -N 1
+#SBATCH -t 04:00:00
+#SBATCH -L SCRATCH,project
+#SBATCH -C haswell
+
+# ADM an all-in-one shell script for running the sweeps and external-match
+# ADM files for a data release. Although you can slurm this, it also usually runs to
+# ADM completion within 4 hours on an interactive node, e.g.
+#   salloc -N 1 -C haswell -t 04:00:00 --qos interactive -L SCRATCH,project
+# or
+#   salloc --nodes 1 --qos interactive --time 04:00:00 --constraint cpu
+
+# ADM the easiest way to run this is using a docker container. This can
+# ADM be achieved by grabbing an interactive node and then executing, e.g.:
+#   srun [args] shifter --image=docker:legacysurvey/legacypipe:DR11.0.1 ./this-script.sh
+
+# ADM if this is true, make the list of bricks. If that was already
+# ADM done, set this to false as a speed-up.
+makelist=true
+
+# ADM if this is true, don't overwrite any existing files. This
+# ADM is useful for recovering faster if there's a failure. It should
+# ADM be safe to leave this as true and never overwrite existing files.
+mopup=true
+
+# ADM you may need to change the top-level environment variables from
+# -------------------------------here--------------------------------
+
+# ADM set the data release and hence the main input directory.
+dr=dr11
+drdir=/global/cfs/cdirs/cosmo/work/legacysurvey/$dr
+drdir=/pscratch/sd/a/adamyers/legacysurvey/$dr
+
+# ADM write to scratch.
+droutdir=$SCRATCH/$dr
+
+# ADM uncomment these to pull and enter the docker container.
+# ADM this is useful if NOT parallelizing across multiple nodes using srun.
+# shifterimg pull docker:legacysurvey/legacypipe:DR10.0.1
+# shifter --image docker:legacysurvey/legacypipe:DR10.0.1 bash
+
+# ADM example set-ups for using custom code are commented out!
+# ADM the UN-commented code is for the docker container.
+export LEGACYPIPE_DIR=/src/legacypipe
+
+# ADM an abstruse way of getting my home directory as $HOME
+# ADM can be redefined in docker containers.
+HOM=`eval echo "~$USER"`
+# ADM the next line can be uncommented for, e.g., developing code.
+export LEGACYPIPE_DIR=$HOM/git/legacypipe/
+
+export PYTHONPATH=/usr/local/lib/python:$LEGACYPIPE_DIR/py
+
+# ADM location of external-match files.
+export SDSSDIR=/global/cfs/cdirs/sdss/data/sdss/
+
+# ------------------------------to here------------------------------
+
+# ADM a sensible number of processors on which to run.
+export NUMPROC=$((SLURM_CPUS_ON_NODE / 2))
+# ADM the sweeps need more memory since we started to write three files.
+# ADM $SLURM_CPUS_ON_NODE / 6 works well for dr10.
+export SWEEPS_NUMPROC=$((SLURM_CPUS_ON_NODE / 6))
+
+# ADM if the bricks and matching files are common to all surveys then
+# ADM uncomment the next line and comment the subsequent for line.
+#for survey in ""
+# ADM run once for each of the DECaLS and MzLS/BASS surveys.
+for survey in south
+do
+
+    # ADM the file that holds general information about LS bricks.
+    export BRICKSFILE=$drdir/survey-bricks.fits.gz
+
+    # ADM set up the per-survey input and output directories.
+    export INDIR=$drdir/$survey
+    echo "working on input directory $INDIR"
+    export TRACTOR_INDIR=$INDIR/tractor/
+
+    export OUTDIR=$droutdir/$survey
+    echo "writing to output directory $OUTDIR"
+    export SWEEP_OUTDIR=$OUTDIR/sweep
+    export EXTERNAL_OUTDIR=$OUTDIR/external
+    export TRACTOR_FILELIST=$OUTDIR/tractor_filelist
+
+    mkdir -p "$SWEEP_OUTDIR"
+    mkdir -p "$EXTERNAL_OUTDIR"
+
+    # ADM write the bricks of interest to the output directory.
+    if "$makelist"; then
+        echo making new list of bricks to process
+        find "$TRACTOR_INDIR" -name 'tractor-*.fits' > "$TRACTOR_FILELIST"
+        echo "wrote list of tractor files to $TRACTOR_FILELIST"
+    else
+        echo "makelist is $makelist: Refusing to make new list of bricks to process."
+    fi
+
+    # ADM run the sweeps. Should never have to use the --ignore option here,
+    # ADM which usually means there are some discrepancies in the data model!
+    echo "running sweeps on $SWEEPS_NUMPROC nodes"
+    if "$mopup"; then
+        echo "Mopping up (won't overwrite existing sweep files)"
+        time python "$LEGACYPIPE_DIR/bin/generate-sweep-files.py" \
+             -v --numproc "$SWEEPS_NUMPROC" -f fits -F "$TRACTOR_FILELIST" --schema "blocks$dr" \
+             --mopup -d "$BRICKSFILE" "$TRACTOR_INDIR" "$SWEEP_OUTDIR"
+    else
+        time python "$LEGACYPIPE_DIR/bin/generate-sweep-files.py" \
+             -v --numproc "$SWEEPS_NUMPROC" -f fits -F "$TRACTOR_FILELIST" --schema "blocks$dr" \
+             -d "$BRICKSFILE" "$TRACTOR_INDIR" "$SWEEP_OUTDIR"
+    fi
+    echo "done running sweeps for the $survey"
+
+    # ADM run each of the external matches.
+    echo "making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits"
+    time python "$LEGACYPIPE_DIR/bin/match-external-catalog.py" \
+         -v --numproc "$NUMPROC" -f fits -F "$TRACTOR_FILELIST" \
+         "$SDSSDIR/dr7/dr7qso.fit.gz" \
+         "$TRACTOR_INDIR" \
+         "$EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits" --copycols SMJD PLATE FIBER RERUN
+    echo "done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr7Q.fits"
+
+    echo "making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr12Q.fits"
+    time python "$LEGACYPIPE_DIR/bin/match-external-catalog.py" \
+         -v --numproc "$NUMPROC" -f fits -F "$TRACTOR_FILELIST" \
+         "$SDSSDIR/dr12/boss/qso/DR12Q/DR12Q.fits" \
+         "$TRACTOR_INDIR" \
+         "$EXTERNAL_OUTDIR/survey-$dr-$survey-dr12Q.fits" --copycols MJD PLATE FIBERID RERUN_NUMBER
+    echo "done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr12Q.fits"
+
+    echo "making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits"
+    time python "$LEGACYPIPE_DIR/bin/match-external-catalog.py" \
+         -v --numproc "$NUMPROC" -f fits -F "$TRACTOR_FILELIST" \
+         "$SDSSDIR/dr12/boss/qso/DR12Q/Superset_DR12Q.fits" \
+         "$TRACTOR_INDIR" \
+         "$EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits" --copycols MJD PLATE FIBERID
+    echo "done making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr12Q.fits"
+
+    echo "making $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits"
+    time python "$LEGACYPIPE_DIR/bin/match-external-catalog.py" \
+         -v --numproc "$NUMPROC" -f fits -F "$TRACTOR_FILELIST" \
+         "$SDSSDIR/dr16/sdss/spectro/redux/specObj-dr16.fits" \
+         "$TRACTOR_INDIR" \
+         "$EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits" --copycols MJD PLATE FIBERID RUN2D
+    echo "done making $EXTERNAL_OUTDIR/survey-$dr-$survey-specObj-dr16.fits"
+
+    echo "making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits"
+    time python "$LEGACYPIPE_DIR/bin/match-external-catalog.py" \
+         -v --numproc "$NUMPROC" -f fits -F "$TRACTOR_FILELIST" \
+         "$SDSSDIR/dr16/eboss/qso/DR16Q/DR16Q_v4.fits" \
+         "$TRACTOR_INDIR" \
+         "$EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits" --copycols MJD PLATE FIBERID
+    echo "done making $EXTERNAL_OUTDIR/survey-$dr-$survey-dr16Q-v4.fits"
+
+    echo "making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr16Q-v3.fits"
+    time python "$LEGACYPIPE_DIR/bin/match-external-catalog.py" \
+         -v --numproc "$NUMPROC" -f fits -F "$TRACTOR_FILELIST" \
+	     "$SDSSDIR/dr16/eboss/qso/DR16Q/DR16Q_Superset_v3.fits" \
+         "$TRACTOR_INDIR" \
+         "$EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr16Q-v3.fits" --copycols MJD PLATE FIBERID
+    echo "done making $EXTERNAL_OUTDIR/survey-$dr-$survey-superset-dr16Q-v3.fits"
+done
+
+wait
+echo done writing sweeps and externals for all surveys

--- a/bin/generate-sweep-files.py
+++ b/bin/generate-sweep-files.py
@@ -57,6 +57,7 @@ def main():
         'ra' : sweep_schema_ra(360),
         'blocks' : sweep_schema_blocks(36, 36),
         'blocksdr10' : sweep_schema_blocks(72, 36),
+        'blocksdr11' : sweep_schema_blocks(72, 36),
         'dec' : sweep_schema_dec(180),
         }
 
@@ -501,20 +502,20 @@ SWEEP_DTYPE = np.dtype([
     ('PSFDEPTH_W1', '>f4'),
     ('PSFDEPTH_W2', '>f4'),
     ('WISE_COADD_ID', 'S8'),
-    ('LC_FLUX_W1', '>f4', (17,)),
-    ('LC_FLUX_W2', '>f4', (17,)),
-    ('LC_FLUX_IVAR_W1', '>f4', (17,)),
-    ('LC_FLUX_IVAR_W2', '>f4', (17,)),
-    ('LC_NOBS_W1', '>i2', (17,)),
-    ('LC_NOBS_W2', '>i2', (17,)),
-    ('LC_MJD_W1', '>f8', (17,)),
-    ('LC_MJD_W2', '>f8', (17,)),
-    ('LC_FRACFLUX_W1', '>f4', (17,)),
-    ('LC_FRACFLUX_W2', '>f4', (17,)),
-    ('LC_RCHISQ_W1', '>f4', (17,)),
-    ('LC_RCHISQ_W2', '>f4', (17,)),
-    ('LC_EPOCH_INDEX_W1', '>i2', (17,)),
-    ('LC_EPOCH_INDEX_W2', '>i2', (17,)),
+    ('LC_FLUX_W1', '>f4', (25,)),
+    ('LC_FLUX_W2', '>f4', (25,)),
+    ('LC_FLUX_IVAR_W1', '>f4', (25,)),
+    ('LC_FLUX_IVAR_W2', '>f4', (25,)),
+    ('LC_NOBS_W1', '>i2', (25,)),
+    ('LC_NOBS_W2', '>i2', (25,)),
+    ('LC_MJD_W1', '>f8', (25,)),
+    ('LC_MJD_W2', '>f8', (25,)),
+    ('LC_FRACFLUX_W1', '>f4', (25,)),
+    ('LC_FRACFLUX_W2', '>f4', (25,)),
+    ('LC_RCHISQ_W1', '>f4', (25,)),
+    ('LC_RCHISQ_W2', '>f4', (25,)),
+    ('LC_EPOCH_INDEX_W1', '>i2', (25,)),
+    ('LC_EPOCH_INDEX_W2', '>i2', (25,)),
 #    ('FRACDEV', '>f4'),
 #    ('FRACDEV_IVAR', '>f4'),
     ('SHAPE_R', '>f4'),
@@ -601,7 +602,8 @@ def parse_args():
         help="if set, don't overwrite existing files (as a speed-up)")
     ap.add_argument('-I', "--ignore-errors", action='store_true')
 
-    ap.add_argument('-S', "--schema", choices=['blocks', 'blocksdr10', 'dec', 'ra'],
+    ap.add_argument('-S', "--schema",
+                    choices=['blocks', 'blocksdr10', 'blocksdr11', 'ra', 'dec'],
             default='blocks',
             help="""Decomposition schema. Still being tuned. """)
 


### PR DESCRIPTION
This PR updates the python code (`generate-sweep-files.py`) for generating sweeps files and adds a shell script (`dr11-sweeps-and-external.sh`) for making sweeps and external-match files, for DR11.

This is _Work in Progress_ until we have the final data model in place for DR11, so please don't merge this yet!